### PR TITLE
Adding additional linting config to the JS task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿# editorconfig.org
+# editorconfig.org
 root = true
 
 [*]
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [**/*.{config,csproj,dotsettings,feature,fxcop,markdown,md,ncrunch*,ndepend,rb,targets,xml,xsd,json}]
 indent_size = 2
 
-[**/*.{cs,cshtml,css,html,js,less}]
+[**/*.{cs,cshtml,scss,css,html,js,less}]
 indent_size = 4

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Here is the outline of the configuration options, descriptions of each are below
         srcFile,
         jsDir,
         distFile,
+        lintPaths,
         applyRevision
     },
     img: {
@@ -296,6 +297,16 @@ Root dist directory for your assets.
   Default: `'script.js'`
 
  The filename for the bundled JavaScript.
+
+-#### `lintPaths`
+
+  Type: `array`
+
+  Default: `[ ]`
+
+  Allows additional paths to be included or excluded from the JS linting task.
+
+  By default, the task will lint all files within the `jsDir` directory.
 
 - #### `applyRevision`
 

--- a/config.js
+++ b/config.js
@@ -34,6 +34,7 @@ const ConfigOptions = () => {
         js: {
             srcFile: 'index.js',
             jsDir: 'js',
+            lintPaths: [''],
             distFile: 'script.js',
             applyRevision: true
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian@lowflyingowls.co.uk> (http://www.damianmullins.com)",
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/justeat/gulp-build-fozzie#readme",
   "scripts": {
-    "prepublish": "yarn test",
+    "prepublishOnly": "yarn test",
     "test": "jest",
     "release-patch": "release-it patch --non-interactive -p",
     "release-minor": "release-it minor --non-interactive -p",

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -1,4 +1,4 @@
-﻿const gulp = require('gulp');
+const gulp = require('gulp');
 
 /**
  * `default` Task
@@ -6,4 +6,4 @@
  *
  *
  */
-gulp.task('default', ['css', 'scripts', 'images', 'service-worker']);
+gulp.task('default', ['css', 'scripts', 'images']);

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -46,7 +46,9 @@ gulp.task('scripts', callback => {
  * Uses config rules to test for valid JS.
  *
  */
-gulp.task('scripts:lint', () => gulp.src(`${pathBuilder.jsSrcDir}/**`)
+const lintSrc = [`${pathBuilder.jsSrcDir}/**`].concat(config.js.lintPaths);
+
+gulp.task('scripts:lint', () => gulp.src(lintSrc)
     .pipe(cache('scripts-lint'))
 
     // stops watch from breaking on error


### PR DESCRIPTION
- Add `lintPaths` to the JS task
- Moving prepublish to prepublishOnly (as expected behaviour)
- Taking service-worker out of the default build as it errors when no path is specified