### PR TITLE
v1.15.0 – Error handling and SCSS watch building updates

### DIFF
--- a/config.js
+++ b/config.js
@@ -97,7 +97,7 @@ const ConfigOptions = () => {
              */
             changeEvent (evt) {
                 gutil.log();
-                gutil.log(gutil.colors.cyan.bold(`â¯â¯ File: ${path.basename(evt.path)}`), 'was', gutil.colors.magenta(evt.type));
+                gutil.log(gutil.colors.cyan.bold(`❯❯ File: ${path.basename(evt.path)}`), 'was', gutil.colors.magenta(evt.type));
             },
 
             /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -85,8 +85,9 @@ gulp.task('scripts:bundle', ['clean:scripts'], () => browserify(`${pathBuilder.j
     .transform(babelify)
     .bundle()
 
-    // handle errors
-    .on('error', config.gulp.onError)
+    .pipe(plumber({
+        errorHandler: config.gulp.onError
+    }))
 
     // move the source map outisde of the JS file when not in prod
     .pipe(gulpif(config.isDev,

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -30,7 +30,10 @@ gulp.task('watch', callback => {
  */
 gulp.task('watch:css', () => {
 
-    gulp.watch(`${pathBuilder.scssSrcDir}/**/*.scss`, ['css'])
+    gulp.watch([
+            `${pathBuilder.scssSrcDir}/**/*.scss`,
+            'node_modules/@justeat/**/*.scss'
+        ], ['css'])
         .on('change', config.gulp.changeEvent);
 
 });


### PR DESCRIPTION
Updated a typo in the gulp build config and added path to watch files for SCSS so that linked NPM modules will also trigger SCSS updates when changed