### PR TITLE
v2.1.0 – When in dev mode, include symlink paths when linting

### DIFF
--- a/tasks/css.js
+++ b/tasks/css.js
@@ -45,7 +45,7 @@ gulp.task('css', callback => {
  */
 const lintSrc = [`${pathBuilder.scssSrcDir}/**/*.scss`].concat(config.css.lintPaths);
 
-gulp.task('css:lint', () => gulp.src(lintSrc)
+gulp.task('css:lint', () => gulp.src(lintSrc, { follow: config.isDev })
     // stops watch from breaking on error
     .pipe(plumber(config.gulp.onError))
 


### PR DESCRIPTION
When in dev mode, it’s likely we’ll be using yarn/npm link.  By default `gulp.src` doesn’t follow symlinks and so it won’t lint any paths found in linked folders, which means development process is a complete pain in the ass.

This helps with that, meaning that whatever paths you add to the linting rules, even if symlinked, will be found and linted.

N.b. Will likely have to add the same rule for the JS linting at some point in the future, so that we can lint JS modules as we develop too, but as ESLint may behave a little differently will keep that as a separate task.