### PR TITLE
CSS linting updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ That's it! You can now run any of [the Gulp tasks](#the-gulp-tasks).
 
 Runs the following tasks
 
+- #### `scss:lint`
+
+  Lint all SCSS files in the source directory — this runs before the [`css:bundle`](#cssbundle) task.
+
 - #### `css:lint`
 
-  Lint all CSS (SCSS) in the source directory.
+  Lint all CSS files in the dist directory — this runs after the [`css:bundle`](#cssbundle) task.
 
 - #### `clean:css`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -11,7 +11,10 @@ const pathBuilder = require('../pathBuilder');
  * Removes all files form the CSS dist directory.
  *
  */
-gulp.task('clean:css', () => del(`${pathBuilder.cssDistDir}/**/*`));
+gulp.task('clean:css', () => del([
+    `${pathBuilder.cssDistDir}/**/*`,
+    `${pathBuilder.docsCssDistDir}/**/*`
+]));
 
 
 /**

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -11,7 +11,7 @@ const pathBuilder = require('../pathBuilder');
  * Removes all files form the CSS dist directory.
  *
  */
-gulp.task('clean:css', () => del(`${pathBuilder.cssDistDir}/**/*`);
+gulp.task('clean:css', () => del(`${pathBuilder.cssDistDir}/**/*`));
 
 
 /**

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -11,10 +11,7 @@ const pathBuilder = require('../pathBuilder');
  * Removes all files form the CSS dist directory.
  *
  */
-gulp.task('clean:css', () => del([
-    `${pathBuilder.cssDistDir}/**/*`,
-    `${pathBuilder.docsCssDistDir}/**/*`
-]));
+gulp.task('clean:css', () => del(`${pathBuilder.cssDistDir}/**/*`);
 
 
 /**

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -128,18 +128,18 @@ gulp.task('css:bundle', () => gulp.src(`${pathBuilder.scssSrcDir}/**/*.scss`)
     // output our unminified files – not for use in prod but useful to be able to debug from
     .pipe(gulp.dest(pathBuilder.cssDistDir))
 
-    // output to docs assets folder
-    .pipe(
-        gulpif(config.docs.outputAssets,
-            gulp.dest(pathBuilder.docsCssDistDir)
-        )
-    )
-
     .pipe(
         postcss([
             // run CSSO – a CSS minifier
             cssnano()
         ])
+    )
+
+    // output to docs assets folder
+    .pipe(
+        gulpif(config.docs.outputAssets,
+            gulp.dest(pathBuilder.docsCssDistDir)
+        )
     )
 
     //add .min suffix to CSS files
@@ -156,13 +156,6 @@ gulp.task('css:bundle', () => gulp.src(`${pathBuilder.scssSrcDir}/**/*.scss`)
 
     // export sourcemaps (as a separate file)
     .pipe(gulpif(config.isDev, sourcemaps.write(undefined, { sourceRoot: null })))
-
-    // output to docs assets folder
-    .pipe(
-        gulpif(config.docs.outputAssets,
-            gulp.dest(pathBuilder.docsCssDistDir)
-        )
-    )
 
     // revision control for caching
     .pipe(rev())

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -74,7 +74,16 @@ gulp.task('css:lint', () => gulp.src(`${pathBuilder.cssDistDir}/**/*.css`)
 
     .pipe(
         postcss([
-            stylelint(),
+            stylelint({
+                config: {
+                    'rules': {
+                        'property-no-unknown': true,
+                        'selector-pseudo-element-no-unknown': true,
+                        'selector-type-no-unknown': true,
+                        'unit-no-unknown': true
+                    }
+                }
+            }),
             reporter({
                 clearMessages: true,
                 throwError: true

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -42,7 +42,7 @@ gulp.task('css', callback => {
 /**
  * scss:lint Task
  * -------------
- * Uses our config rules set in .stylelintrc to validate syntax and structure of the CSS.
+ * Uses our config rules to validate syntax and structure of the SCSS.
  *
  */
 gulp.task('scss:lint', () => gulp.src([`${pathBuilder.scssSrcDir}/**/*.scss`, ...config.css.lintPaths], { follow: config.isDev })
@@ -65,7 +65,7 @@ gulp.task('scss:lint', () => gulp.src([`${pathBuilder.scssSrcDir}/**/*.scss`, ..
 /**
  * scss:lint Task
  * -------------
- * Uses config rules to test for valid SCSS
+ * Uses our config rules to validate syntax and structure of the CSS.
  *
  */
 gulp.task('css:lint', () => gulp.src(`${config.css.distDir}/**/*.css`)

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -63,7 +63,7 @@ gulp.task('scss:lint', () => gulp.src([`${pathBuilder.scssSrcDir}/**/*.scss`, ..
 
 
 /**
- * scss:lint Task
+ * css:lint Task
  * -------------
  * Uses our config rules to validate syntax and structure of the CSS.
  *

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -31,6 +31,7 @@ const pathBuilder = require('../pathBuilder');
 gulp.task('css', callback => {
     runSequence(
         'scss:lint',
+        'clean:css',
         'css:bundle',
         'css:lint',
         callback
@@ -94,7 +95,7 @@ gulp.task('css:lint', () => gulp.src(`${config.css.distDir}/**/*.css`)
  *  ---------
  *
  */
-gulp.task('css:bundle', ['clean:css'], () => gulp.src(`${pathBuilder.scssSrcDir}/**/*.scss`)
+gulp.task('css:bundle', () => gulp.src(`${pathBuilder.scssSrcDir}/**/*.scss`)
     // stops watch from breaking on error
     .pipe(plumber(config.gulp.onError))
 

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -74,13 +74,7 @@ gulp.task('css:lint', () => gulp.src(`${config.css.distDir}/**/*.css`)
 
     .pipe(
         postcss([
-            stylelint({
-                config: {
-                    'rules': {
-                        'selector-type-no-unknown': true
-                    }
-                }
-            }),
+            stylelint(),
             reporter({
                 clearMessages: true,
                 throwError: true

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -68,7 +68,7 @@ gulp.task('scss:lint', () => gulp.src([`${pathBuilder.scssSrcDir}/**/*.scss`, ..
  * Uses our config rules to validate syntax and structure of the CSS.
  *
  */
-gulp.task('css:lint', () => gulp.src(`${config.css.distDir}/**/*.css`)
+gulp.task('css:lint', () => gulp.src(`${pathBuilder.cssDistDir}/**/*.css`)
     // stops watch from breaking on error
     .pipe(plumber(config.gulp.onError))
 


### PR DESCRIPTION
Added a lint task which checks the compiled CSS for issues.

Bumped major version because the `css:lint` task now lints the CSS (rather than the SCSS), with the `scss:lint` task linting the SCSS.