### PR TITLE
v3.8.0 - Adding copy task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.8.0
+------------------------------
+*August 03, 2017*
+
+### Added
+- Added `copy:js`, `copy:css` and `copy:img` tasks to copy over separate files without bundling.  See README for more information.
+
 
 v3.7.0
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ Runs the following tasks
 
 Generate an SVG sprite and copy into the dist directory
 
-### `copy:js`, `copy:css` & `copy:img`
-
-There are three separate copy tasks that can be called; `copy:js`, `copy:css` and `copy:img`.  Each of these copies the specified set of assets from the `src` to the `dist` asset folders.
-
 ### `service-worker`
 
 Runs the following tasks
@@ -167,6 +163,10 @@ Copies the worker's internal scripts to the dist directory.
 - #### `service-worker:write`
 
 Generates a service worker to pre-cache the assets defined in the config.
+
+### `copy:js`, `copy:css` & `copy:img`
+
+There are three separate copy tasks that can be called; `copy:js`, `copy:css` and `copy:img`.  Each of these copies the specified set of assets from the `src` to the `dist` asset folders.
 
 ### `watch`
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Runs the following tasks
 
 Generate an SVG sprite and copy into the dist directory
 
+### `copy:js`, `copy:css` & `copy:img`
+
+There are three separate copy tasks that can be called; `copy:js`, `copy:css` and `copy:img`.  Each of these copies the specified set of assets from the `src` to the `dist` asset folders.
+
 ### `service-worker`
 
 Runs the following tasks
@@ -247,6 +251,11 @@ Here is the outline of the configuration options, descriptions of each are below
         dynamicFileStrategy,
         importScripts,
         cacheId
+    },
+    copy: {
+        js,
+        css,
+        img
     },
     docs: {
         rootDir,
@@ -469,6 +478,37 @@ Root dist directory for your assets.
   Default: `''`
 
   An optional string used to differentiate caches on the same origin during local development.
+
+### `copy`
+
+- #### `js`, `css` & `img`
+
+  Type: `Object`
+
+  Default: `null`
+
+  Each of `copy.js`, `copy:css` and `copy:img` takes an object list of assets in the format:
+
+  ```js
+    copy:
+      js: {
+        'prism': {
+            path: '/libs/prism.min.js',
+            dest: '/libs',
+            revision: false,
+        }
+      }
+    }
+  ```
+
+  In which:
+  - `path` is a string specifying the path within the relevant asset `src` folder of the asset to be copied.
+  - `dest` is a string specifying that destination folder for the asset to be copied to, within the relevant asset `dist` folder.
+  - `revision` is a boolean such that if it is true, the asset will be [revision hashed](https://www.npmjs.com/package/gulp-rev) when copied to it’s destination.
+
+  `path` and `dest` must always be defined for each asset you wish to copy.
+
+  The object key (which in the above example is `prism`) of each asset is simply for your own use to identify each asset in your config.
 
 
 ### `docs`

--- a/README.md
+++ b/README.md
@@ -485,9 +485,9 @@ Root dist directory for your assets.
 
   Type: `Object`
 
-  Default: `null`
+  Default: `{}`
 
-  Each of `copy.js`, `copy:css` and `copy:img` takes an object list of assets in the format:
+  Each of `copy.js`, `copy.css` and `copy.img` takes an object list of assets in the format:
 
   ```js
     copy:

--- a/config.js
+++ b/config.js
@@ -62,6 +62,11 @@ const ConfigOptions = () => {
         },
 
         /**
+         * Copy takes an object of assets to copy from src to dist folders
+         */
+        copy: {},
+
+        /**
          * Documentation-related variables
          */
         docs: {

--- a/config.js
+++ b/config.js
@@ -64,7 +64,11 @@ const ConfigOptions = () => {
         /**
          * Copy takes an object of assets to copy from src to dist folders
          */
-        copy: {},
+        copy: {
+            js: {},
+            css: {},
+            img: {}
+        },
 
         /**
          * Documentation-related variables

--- a/config.js
+++ b/config.js
@@ -145,6 +145,7 @@ const ConfigOptions = () => {
                 js: Object.assign(config.js, options.js),
                 img: Object.assign(config.img, options.img),
                 sw: Object.assign(config.sw, options.sw),
+                copy: Object.assign(config.copy, options.copy),
                 docs: Object.assign(config.docs, options.docs),
                 misc: Object.assign(config.misc, options.misc),
                 gulp: Object.assign(config.gulp, options.gulp)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,0 +1,58 @@
+const gulp = require('gulp');
+const gutil = require('gulp-util');
+const plumber = require('gulp-plumber');
+const gulpif = require('gulp-if');
+
+const rev = require('gulp-rev');
+const config = require('../config');
+const pathBuilder = require('../pathBuilder');
+
+
+const copy = fileType => {
+    Object.keys(config.copy[fileType]).forEach(assetId => {
+        const asset = config.copy[fileType][assetId];
+        const fileTypeCapitalised = fileType.charAt(0).toUpperCase() + fileType.slice(1);
+
+        const assetSrc = pathBuilder[`${fileType}SrcDir`] + asset.path;
+        const assetDist = pathBuilder[`${fileType}DistDir`] + asset.dest;
+        const assetDocsDist = pathBuilder[`docs${fileTypeCapitalised}DistDir`] + asset.dest;
+
+        if (asset.path !== undefined && asset.dest !== undefined) {
+
+            gutil.log(`❯❯ Copying ${assetSrc} to ${assetDist}`);
+
+            gulp.src(assetSrc)
+                .pipe(plumber(config.gulp.onError))
+
+                .pipe(gulpif(asset.revision,
+                    rev()
+                ))
+
+                .pipe(gulp.dest(assetDist))
+
+                // output to docs assets folder
+                .pipe(gulpif(config.docs.outputAssets,
+                    gulp.dest(assetDocsDist)
+                ));
+        } else {
+            gutil.log(gutil.colors.red.bold(`Error copying file - path not defined`));
+        }
+    });
+};
+
+// copy all the asset JS over to the docs folder
+gulp.task('copy:js', () => {
+    copy('js');
+});
+
+// copy all the asset JS over to the docs folder
+gulp.task('copy:css', () => {
+    copy('css');
+});
+
+// copy all the asset JS over to the docs folder
+gulp.task('copy:img', () => {
+    copy('img');
+});
+
+

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -35,7 +35,7 @@ const copy = fileType => {
                     gulp.dest(assetDocsDist)
                 ));
         } else {
-            gutil.log(gutil.colors.red.bold(`Error copying file - path not defined`));
+            gutil.log(gutil.colors.red.bold('Error copying file - path not defined'));
         }
     });
 };

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -33,6 +33,7 @@ gulp.task('css', callback => {
         'scss:lint',
         'clean:css',
         'css:bundle',
+        'copy:css',
         'css:lint',
         callback
     );

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -21,6 +21,7 @@ gulp.task('images', callback => {
     runSequence(
         'clean:images',
         ['images:optimise', 'images:svg-sprite'],
+        'copy:img',
         callback
     );
 });

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -37,6 +37,7 @@ gulp.task('scripts', callback => {
         'scripts:test',
         'clean:scripts',
         'scripts:bundle',
+        'copy:js',
         callback
     );
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -356,6 +356,31 @@ describe('service worker config', () => {
     });
 });
 
+describe('copy config', () => {
+
+    it('copy config should be set to an empty object', () => {
+        expect(config.copy).toEqual({});
+    });
+
+    it('copy config can be updated', () => {
+        // Arrange
+        const js = {
+            prism: {
+                path: '/libs/prism.min.js',
+                dest: '/libs'
+            }
+        };
+
+        // Act
+        config.update({ copy: { js } });
+
+        // Assert
+        expect(config.copy.js.prism.path).toBe('/libs/prism.min.js');
+    });
+
+});
+
+
 describe('documentation config', () => {
 
     it('root directory should be set', () => {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -358,8 +358,16 @@ describe('service worker config', () => {
 
 describe('copy config', () => {
 
-    it('copy config should be set to an empty object', () => {
-        expect(config.copy).toEqual({});
+    it('copy.js config should be set', () => {
+        expect(config.copy.js).toEqual({});
+    });
+
+    it('copy.css config should be set', () => {
+        expect(config.copy.css).toEqual({});
+    });
+
+    it('copy.img config should be set', () => {
+        expect(config.copy.img).toEqual({});
     });
 
     it('copy config can be updated', () => {


### PR DESCRIPTION
Added `copy:js`, `copy:css` and `copy:img` tasks to copy over separate files without bundling.  See README for more information.
