### PR TITLE
v5.0.0 – Updating JS bundling to cope with multiple entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v5.0.0
+------------------------------
+*August 14, 2017*
+
+### Changed
+- JavaScript task can now handle multiple files to be bundled via Browserify/Babel.  Check the README for updated config changes.
+- Updatd `copy` task error handling
+
 v4.5.0
 ------------------------------
 *August 15, 2017*

--- a/README.md
+++ b/README.md
@@ -282,11 +282,16 @@ Here is the outline of the configuration options, descriptions of each are below
         sourcemaps
     },
     js: {
-        srcFile,
+        files: {
+            main: {
+                srcPath,
+                distFile,
+                applyRevision
+            },
+            …
+        ],
         jsDir,
         lintPaths,
-        distFile,
-        applyRevision
     },
     img: {
         imgDir,
@@ -403,13 +408,48 @@ Root dist directory for your assets.
 
 ### `js`
 
-- #### `srcFile`
+#### `files`
+
+Type: `Object`
+
+Default:
+
+```
+{
+    main {
+        srcPath: 'index.js',
+        distFile: 'script.js',
+        applyRevision: true
+    }
+}
+```
+
+An Object, that takes one or more child objects each describing a JavaScript bundle entry point and destination.  Each of these objects can have the following properties:
+
+- ##### `srcPath`
 
   Type: `string`
 
   Default: `'index.js'`
 
-  The filename for the entry point to your es2015 code.
+  The file path to a bundle entry point in your JavaScript.
+
+- ##### `distFile`
+
+  Type: `string`
+
+  Default: `'script.js'`
+
+ The filename for the JavaScript bundle once compiled.
+
+- ##### `applyRevision`
+
+  Type: `boolean`
+
+  Default: true
+
+  Will add a content hash to the filename.
+
 
 - #### `jsDir`
 
@@ -417,7 +457,7 @@ Root dist directory for your assets.
 
   Default: `'js'`
 
-  Name of the directory where your JavaScript files are kept.
+  Name of the directory where all of your JavaScript files are kept.
 
   Compiled JavaScript files will be placed inside a directory with the same name.
 
@@ -431,21 +471,6 @@ Root dist directory for your assets.
 
   By default, the task will lint all files within the `jsDir` directory.
 
-- #### `distFile`
-
-  Type: `string`
-
-  Default: `'script.js'`
-
- The filename for the bundled JavaScript.
-
-- #### `applyRevision`
-
-  Type: `boolean`
-
-  Default: true
-
-  Will add a content hash to the filename.
 
 
 ### `img`
@@ -750,7 +775,7 @@ const { pathBuilder } = require('@justeat/gulp-build-fozzie');
 
 gulp.task('scss', () => gulp.src(`${pathBuilder.scssSrcDir}/**`)
 
-...
+…
 ```
 
 These are the paths which the `pathBuilder` object provides.

--- a/config.js
+++ b/config.js
@@ -32,11 +32,15 @@ const ConfigOptions = () => {
          * Javascript-related variables
          */
         js: {
-            srcFile: 'index.js',
+            files: {
+                main: {
+                    srcPath: 'index.js',
+                    distFile: 'script.js',
+                    applyRevision: true
+                }
+            },
             jsDir: 'js',
-            lintPaths: [''],
-            distFile: 'script.js',
-            applyRevision: true
+            lintPaths: ['']
         },
 
         /**
@@ -148,14 +152,18 @@ const ConfigOptions = () => {
                     process.exit(1);
                 }
 
-                this.emit('end');
+                if (this.emit) { this.emit('end'); }
             }
         },
 
         update (options = {}) {
             config = Object.assign(config, options, {
                 css: Object.assign(config.css, options.css),
-                js: Object.assign(config.js, options.js),
+                js: Object.assign(config.js, options.js, {
+                    files: Object.assign(config.js.files, (options.js ? options.js.files : {}), {
+                        main: Object.assign(config.js.files.main, (options.js && options.js.files ? options.js.files.main : {}))
+                    })
+                }),
                 img: Object.assign(config.img, options.img),
                 importedAssets: Object.assign(config.importedAssets, options.importedAssets),
                 sw: Object.assign(config.sw, options.sw),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",
@@ -39,6 +39,7 @@
     "eslint": "^4.3.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jest": "^20.0.0",
+    "event-stream": "^3.3.4",
     "exorcist": "^0.4.0",
     "eyeglass": "^1.2.1",
     "filesizegzip": "^2.0.0",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -104,8 +104,8 @@ gulp.task('copy:assets', callback => {
         gutil.log(`❯❯ Copying any assets in ${pkg.path} to ${pathBuilder.importedAssetsDistDir}/${pkg.name}`);
         copyAssets(pkg.path, `${pathBuilder.importedAssetsDistDir}/${pkg.name}`, err => {
             if (err) {
-                config.gulp.onError(err);
-                reject();
+                err.plugin = 'copyAssets';
+                reject(err);
             } else resolve();
         });
     });
@@ -119,8 +119,8 @@ gulp.task('copy:assets', callback => {
 
         Promise
             .all(promises)
-            .catch(config.gulp.onError)
-            .then(() => callback());
+            .then(() => callback())
+            .catch(config.gulp.onError);
     });
 
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -123,19 +123,19 @@ describe('css config', () => {
 
 describe('javascript config', () => {
 
-    it('src file should be set', () => {
-        expect(config.js.srcFile).toBe('index.js');
+    it('src path for bundle should be set', () => {
+        expect(config.js.files.main.srcPath).toBe('index.js');
     });
 
-    it('src file can be updated', () => {
+    it('src path can be updated', () => {
         // Arrange
-        const srcFile = 'app.js';
+        const srcPath = 'app.js';
 
         // Act
-        config.update({ js: { srcFile } });
+        config.update({ js: { files: { main: { srcPath } } } });
 
         // Assert
-        expect(config.js.srcFile).toBe(srcFile);
+        expect(config.js.files.main.srcPath).toBe(srcPath);
     });
 
     it('javascript directory should be set', () => {
@@ -169,7 +169,7 @@ describe('javascript config', () => {
     });
 
     it('dist file should be set', () => {
-        expect(config.js.distFile).toBe('script.js');
+        expect(config.js.files.main.distFile).toBe('script.js');
     });
 
     it('dist file can be updated', () => {
@@ -177,14 +177,14 @@ describe('javascript config', () => {
         const distFile = 'app.js';
 
         // Act
-        config.update({ js: { distFile } });
+        config.update({ js: { files: { main: { distFile } } } });
 
         // Assert
-        expect(config.js.distFile).toBe(distFile);
+        expect(config.js.files.main.distFile).toBe(distFile);
     });
 
     it('apply revision should be true', () => {
-        expect(config.js.applyRevision).toBe(true);
+        expect(config.js.files.main.applyRevision).toBe(true);
     });
 
     it('apply revision can be updated', () => {
@@ -192,10 +192,10 @@ describe('javascript config', () => {
         const applyRevision = false;
 
         // Act
-        config.update({ js: { applyRevision } });
+        config.update({ js: { files: { main: { applyRevision } } } });
 
         // Assert
-        expect(config.js.applyRevision).toBe(applyRevision);
+        expect(config.js.files.main.applyRevision).toBe(applyRevision);
     });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,6 +3596,18 @@ etag@^1.7.0, etag@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
 
+event-stream@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
@@ -4153,6 +4165,10 @@ fresh@0.5.0:
 fresh@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
@@ -6997,6 +7013,10 @@ map-schema@^0.2.3, map-schema@^0.2.4:
     sort-object-arrays "^0.1.1"
     union-value "^0.2.3"
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
 map-visit@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-0.1.5.tgz#dbe43927ce5525b80dfc1573a44d68c51f26816b"
@@ -8017,6 +8037,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
 
 pbkdf2@^3.0.3:
   version "3.0.12"
@@ -9609,6 +9635,12 @@ split-string@^2.1.0:
   dependencies:
     extend-shallow "^2.0.1"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -9684,6 +9716,12 @@ stream-combiner@^0.2.2:
   dependencies:
     duplexer "~0.1.1"
     through "~2.3.4"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-consume@^0.1.0, stream-consume@~0.1.0:
   version "0.1.0"
@@ -10193,7 +10231,7 @@ through2@^0.6.0, through2@^0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-"through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
### Changed
- JavaScript task can now handle multiple files to be bundled via Browserify/Babel.  Check the README for updated config changes.
- Updatd `copy` task error handling