### PR TITLE
Use f-copy-assets rather than npm-assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v5.5.0
+------------------------------
+*August 24, 2017*
+
+### Added
+- Added `config.importedAssets.verbose` option.
+- Added unit tests for `config.importedAssets.verbose` option.
+
+### Changed
+- `copy:assets` task uses the `f-copy-assets` module rather than `npm-assets`
+- The Readme `config.importedAssets` section was updated.
+
 v5.4.0
 ------------------------------
 *August 22, 2017*

--- a/README.md
+++ b/README.md
@@ -310,7 +310,8 @@ Here is the outline of the configuration options, descriptions of each are below
         svgSpriteFilename
     },
     importedAssets: {
-        importedAssetsSrcGlob
+        importedAssetsSrcGlob,
+        verbose
     },
     sw: {
         isEnabled,
@@ -519,6 +520,14 @@ An Object, that takes one or more child objects each describing a JavaScript bun
   Default: `'node_modules/@justeat/*/'`
 
   Glob of packages containing assets to be copied to `assetDistDir`.
+
+- #### `verbose`
+
+  Type: `boolean`
+
+  Default: `'true'`
+
+  Whether to log the names of all assets being copied. Passed on to [f-copy-assets](https://github.com/justeat/f-copy-assets).
 
 
 ### `sw`

--- a/config.js
+++ b/config.js
@@ -55,7 +55,8 @@ const ConfigOptions = () => {
          * Imported assets related variables
          */
         importedAssets: {
-            importedAssetsSrcGlob: 'node_modules/@justeat/*/'
+            importedAssetsSrcGlob: 'node_modules/@justeat/*/',
+            verbose: true
         },
 
         /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@justeat/eslint-config-fozzie": "^1.2.0",
+    "@justeat/f-copy-assets": "^0.1.0",
     "@justeat/stylelint-config-fozzie": "^1.1.0",
     "assemble": "^0.24.3",
     "autoprefixer": "^7.1.2",
@@ -43,7 +44,6 @@
     "exorcist": "^0.4.0",
     "eyeglass": "^1.2.1",
     "filesizegzip": "^2.0.0",
-    "glob": "^7.1.2",
     "gulp": "^3.9.1",
     "gulp-cached": "^1.1.1",
     "gulp-changed": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@justeat/eslint-config-fozzie": "^1.2.0",
-    "@justeat/f-copy-assets": "^0.1.0",
+    "@justeat/f-copy-assets": "^0.3.0",
     "@justeat/stylelint-config-fozzie": "^1.1.0",
     "assemble": "^0.24.3",
     "autoprefixer": "^7.1.2",
@@ -71,7 +71,6 @@
     "helper-markdown": "^1.0.0",
     "helper-md": "^0.2.2",
     "jest-cli": "^20.0.0",
-    "npm-assets": "^0.1.2",
     "postcss-assets": "^4.2.0",
     "postcss-reporter": "^5.0.0",
     "postcss-scss": "^1.0.2",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -89,15 +89,13 @@ gulp.task('copy:fonts', () => {
  * Copy assets from from packages to the dist folder.
  *
  */
-gulp.task('copy:assets', callback => {
-    const opts = {
+gulp.task('copy:assets', callback =>
+    copyAssets({
         pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
         dest: config.assetDistDir,
-        verbose: true,
+        verbose: config.importedAssets.verbose,
         logger: gutil.log
-    };
-
-    copyAssets(opts)
+    })
         .then(() => callback())
-        .catch(config.gulp.onError);
-});
+        .catch(config.gulp.onError)
+);

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,11 +1,9 @@
+const copyAssets = require('@justeat/f-copy-assets');
 const gulp = require('gulp');
 const gutil = require('gulp-util');
 const plumber = require('gulp-plumber');
 const gulpif = require('gulp-if');
-const copyAssets = require('npm-assets');
 const rev = require('gulp-rev');
-const path = require('path');
-const glob = require('glob');
 
 const config = require('../config');
 const pathBuilder = require('../pathBuilder');
@@ -92,36 +90,14 @@ gulp.task('copy:fonts', () => {
  *
  */
 gulp.task('copy:assets', callback => {
-
-    const getPackage = filepath => {
-        const split = filepath.split('/'); // e.g. [...'@justeat', '', 'fozzie', '']
-        return {
-            filepath,
-            name: split[split.length - 2]
-        };
+    const opts = {
+        pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
+        dest: config.assetDistDir,
+        verbose: true,
+        logger: gutil.log
     };
 
-    const copyFromPackage = pkg => new Promise((resolve, reject) => {
-        gutil.log(`❯❯ Copying any assets from ${pkg.name} to ${path.dirname(config.assetDistDir)}`);
-        copyAssets(`${pkg.filepath}`, `${path.dirname(config.assetDistDir)}`, err => {
-            if (err) {
-                err.plugin = 'copyAssets';
-                reject(err);
-            } else resolve();
-        });
-    });
-
-    glob(config.importedAssets.importedAssetsSrcGlob, (err, files) => {
-        if (err) config.gulp.onError(err);
-
-        const promises = files
-            .map(getPackage)
-            .map(copyFromPackage);
-
-        Promise
-            .all(promises)
-            .then(() => callback())
-            .catch(config.gulp.onError);
-    });
-
+    copyAssets(opts)
+        .then(() => callback())
+        .catch(config.gulp.onError);
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -250,6 +250,21 @@ describe('imported assets config', () => {
         expect(config.importedAssets.importedAssetsSrcGlob).toBe(importedAssetsSrcGlob);
     });
 
+    it('verbose should be true', () => {
+        expect(config.importedAssets.verbose).toBe(true);
+    });
+
+    it('verbose can be updated', () => {
+        // Arrange
+        const verbose = false;
+
+        // Act
+        config.update({ importedAssets: { verbose } });
+
+        // Assert
+        expect(config.importedAssets.verbose).toBe(verbose);
+    });
+
 });
 
 describe('service worker config', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,9 +25,9 @@
   dependencies:
     eslint-config-airbnb-base "^11.2.0"
 
-"@justeat/f-copy-assets@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-copy-assets/-/f-copy-assets-0.1.0.tgz#35a37e26c0b0c244ce77bf14ff10aa7e5e93bc44"
+"@justeat/f-copy-assets@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-copy-assets/-/f-copy-assets-0.3.0.tgz#dbdda754423874dea3b0c50776a1219518bd44e8"
   dependencies:
     "@justeat/gulp-build-fozzie" "^5.4.0"
     babel-preset-es2015 "^6.24.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,75 @@
   dependencies:
     eslint-config-airbnb-base "^11.2.0"
 
+"@justeat/f-copy-assets@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-copy-assets/-/f-copy-assets-0.1.0.tgz#35a37e26c0b0c244ce77bf14ff10aa7e5e93bc44"
+  dependencies:
+    "@justeat/gulp-build-fozzie" "^5.4.0"
+    babel-preset-es2015 "^6.24.1"
+    fs "^0.0.1-security"
+    glob "^7.1.2"
+    mkdirp "^0.5.1"
+
+"@justeat/gulp-build-fozzie@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-5.4.0.tgz#16afcdc6c64fb5fceabb03a7af6bdf8383eabfc1"
+  dependencies:
+    "@justeat/eslint-config-fozzie" "^1.2.0"
+    "@justeat/stylelint-config-fozzie" "^1.1.0"
+    assemble "^0.24.3"
+    autoprefixer "^7.1.2"
+    babelify "^7.3.0"
+    browser-sync "^2.18.13"
+    browserify "^14.3.0"
+    cssnano "^3.10.0"
+    del "^3.0.0"
+    eslint "^4.3.0"
+    eslint-plugin-import "^2.7.0"
+    eslint-plugin-jest "^20.0.0"
+    event-stream "^3.3.4"
+    exorcist "^0.4.0"
+    eyeglass "^1.2.1"
+    filesizegzip "^2.0.0"
+    glob "^7.1.2"
+    gulp "^3.9.1"
+    gulp-cached "^1.1.1"
+    gulp-changed "^3.1.0"
+    gulp-eslint "^4.0.0"
+    gulp-extname "^0.2.2"
+    gulp-filenames "^4.0.1"
+    gulp-gh-pages "^0.5.4"
+    gulp-if "^2.0.2"
+    gulp-imagemin "^3.2.0"
+    gulp-newer "^1.3.0"
+    gulp-plumber "^1.1.0"
+    gulp-postcss "^7.0.0"
+    gulp-rename "^1.2.2"
+    gulp-rev "^8.0.0"
+    gulp-sass "^3.1.0"
+    gulp-size "^2.1.0"
+    gulp-sourcemaps "^2.6.0"
+    gulp-strip-debug "^1.1.0"
+    gulp-svgmin "^1.2.4"
+    gulp-svgstore "^6.1.0"
+    gulp-tap "^1.0.1"
+    gulp-uglify "^3.0.0"
+    gulp-util "^3.0.8"
+    handlebars-helpers "^0.9.6"
+    helper-markdown "^1.0.0"
+    helper-md "^0.2.2"
+    jest-cli "^20.0.0"
+    npm-assets "^0.1.2"
+    postcss-assets "^4.2.0"
+    postcss-reporter "^5.0.0"
+    postcss-scss "^1.0.2"
+    require-dir "^0.3.1"
+    run-sequence "^2.1.0"
+    stylelint "^8.0.0"
+    sw-precache "^5.1.1"
+    vinyl-buffer "^1.0.0"
+    vinyl-source-stream "^1.1.0"
+
 "@justeat/stylelint-config-fozzie@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/stylelint-config-fozzie/-/stylelint-config-fozzie-1.1.0.tgz#be5f17a2336f0d42ff5f45de0bf6bf88c2d4b825"
@@ -1188,7 +1257,7 @@ babel-polyfill@^6.20.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-es2015@6.24.1:
+babel-preset-es2015@6.24.1, babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -4215,6 +4284,10 @@ fs-promise@^2.0.0:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fs@^0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
 
 fsevents@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
Use f-copy-assets rather than npm-assets to support modules that provide assets in folders other than `dist/` and consumers that don't have a `dist/` folder such as globalweb.

(also globs and nicer logging)

https://github.com/justeat/f-copy-assets