### PR TITLE
v5.5.1 –  Better error handling for JS bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v5.5.2
+------------------------------
+*August 25, 2017*
+
+### Added
+- Better error handling for JS bundling so that errors in the browserify build don’t break the stream
+
+
 v5.5.1
 ------------------------------
 *August 24, 2017*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -108,6 +108,8 @@ gulp.task('scripts:bundle', () => {
         return browserify(file, { debug: config.isDev })
             .transform(babelify)
             .bundle()
+            .on('error', config.gulp.onError)
+
             .pipe(gulpif(config.isDev,
                 exorcist(`${pathBuilder.jsDistDir}/${distFile}.map`))
             )


### PR DESCRIPTION
Better error handling for JS bundling so that errors in the browserify build don’t break the stream :ambulance: