### PR TITLE
Fix bug in copy:assets where task callback was called multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v5.5.1
+------------------------------
+*August 24, 2017*
+
+### Changed
+- Fixed a bug in `copy:assets` where the task callback was called too many times.
+
 v5.5.0
 ------------------------------
 *August 24, 2017*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -89,13 +89,11 @@ gulp.task('copy:fonts', () => {
  * Copy assets from from packages to the dist folder.
  *
  */
-gulp.task('copy:assets', callback =>
+gulp.task('copy:assets', () =>
     copyAssets({
         pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
         dest: config.assetDistDir,
         verbose: config.importedAssets.verbose,
         logger: gutil.log
-    })
-        .then(() => callback())
-        .catch(config.gulp.onError)
+    }).catch(config.gulp.onError)
 );


### PR DESCRIPTION
Missed this one earlier!
Apparently promise completion counts as the end of a gulp task so there's no need to use a callback here.

This was showing up when running `gulp` in certain packages.
```
[17:32:00] Error in plugin 'run-sequence(copy:assets)'
Message:
    task completion callback called too many times
Stack:
Error: task completion callback called too many times
    at finish (C:\_git\gulp-build-fozzie\node_modules\orchestrator\lib\runTask.js:15:10)
    at C:\_git\gulp-build-fozzie\node_modules\orchestrator\lib\runTask.js:43:4
```