### PR TITLE
v6.1.1 - Commit message for docs:deploy updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v6.1.1
+------------------------------
+*September 22, 2017*
+
+### Changed
+- Commit message for docs:deploy updated so that it doesn't clash with commit checks
+
 
 v6.1.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks-dev/docs.js
+++ b/tasks-dev/docs.js
@@ -55,5 +55,7 @@ gulp.task('docs:deploy', callback => {
  *
  */
 gulp.task('docs:release', () => gulp.src(`${pathBuilder.docsDistDir}/**/*`)
-    .pipe(ghPages())
+    .pipe(ghPages({
+        message: `Minor : Documentation Update ${new Date().toISOString()}`
+    }))
 );


### PR DESCRIPTION
### Changed
- Commit message for docs:deploy updated so that it doesn't clash with commit checks