### PR TITLE
Updated log message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v6.2.1
+------------------------------
+*October 04, 2017*
+
+### Changed
+- Changed the log message to display the consuming package name and gulp-build-fozzie version.
+
+
 v6.2.0
 ------------------------------
 *October 03, 2017*

--- a/config.js
+++ b/config.js
@@ -11,7 +11,7 @@ const ConfigOptions = () => {
     const isDev = !isProduction;
     const envLog = isProduction ? 'production' : 'development';
 
-    gutil.log(gutil.colors.yellow(`${gutil.colors.gray(`(v${packageConfig.version})`)} Running Gulp Build Fozzie in ${envLog} mode for ${consumingPackageConfig.name}`));
+    gutil.log(gutil.colors.yellow(`Running Gulp task for ${consumingPackageConfig.name}@${consumingPackageConfig.version} in ${gutil.colors.bold(envLog)} mode ${gutil.colors.gray(`(v${packageConfig.version})`)}`));
 
     let config = {
         isProduction,

--- a/config.js
+++ b/config.js
@@ -1,14 +1,17 @@
 const gutil = require('gulp-util');
 const path = require('path');
+const packageConfig = require('./package.json');
+
+const consumingPackageConfig = require(`${process.cwd()}/package.json`); // eslint-disable-line import/no-dynamic-require
+
 
 const ConfigOptions = () => {
 
-    const projectName = 'Gulp Build Fozzie';
     const isProduction = !!gutil.env.prod;
     const isDev = !isProduction;
-    const envLog = isProduction ? 'Production' : 'Development';
+    const envLog = isProduction ? 'production' : 'development';
 
-    gutil.log(gutil.colors.yellow(`❯❯❯❯ Running ${projectName} task in ${gutil.colors.bold(`${envLog}`)}`));
+    gutil.log(gutil.colors.yellow(`${gutil.colors.gray(`(v${packageConfig.version})`)} Running Gulp Build Fozzie in ${envLog} mode for ${consumingPackageConfig.name}`));
 
     let config = {
         isProduction,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",


### PR DESCRIPTION
The log is now in this format: `Running Gulp task for je-global-web@0.0.1 in development mode (v6.2.1)`.

The message now displays a little better on Windows.