### PR TITLE
v6.4.0 - Apply revision identifier to CSS filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v6.4.0
+------------------------------
+*December 4, 2017*
+
+### Changed
+- Move `applyRevision` variable out of the JS-only config so that it can be used for applying revision identifiers to the CSS files as well.
+- Updated readme to reflect new config structure.
+- Updated unit tests.
+
 
 v6.3.0
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -440,8 +440,7 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
   {
       main: {
           srcPath: 'index.js',
-          distFile: 'script.js',
-          applyRevision: true
+          distFile: 'script.js'
       }
   }
   ```

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Here is the outline of the configuration options, descriptions of each are below
     webRootDir,
     assetSrcDir,
     assetDistDir,
+    applyRevision,
     css: {
         scssDir,
         cssDir,
@@ -294,8 +295,7 @@ Here is the outline of the configuration options, descriptions of each are below
         files: {
             main: {
                 srcPath,
-                distFile,
-                applyRevision
+                distFile                
             },
             …
         ],
@@ -383,6 +383,14 @@ Default: `'dist'`
 
 Root dist directory for your assets.
 
+### `applyRevision`
+
+Type: `boolean`
+
+Default: true
+
+Will add a content hash to the JS and CSS filenames, generating a new filename if any of the file's contents have changed. This can be utilised to force the clients to get the latest version of an updated asset.
+
 ### `css`
 
 - #### `scssDir`
@@ -455,15 +463,6 @@ Root dist directory for your assets.
     Default: `'script.js'`
 
     The filename for the JavaScript bundle once compiled.
-
-  - ##### `applyRevision`
-
-    Type: `boolean`
-
-    Default: true
-
-    Will add a content hash to the filename.
-
 
 - #### `jsDir`
 

--- a/config.js
+++ b/config.js
@@ -20,6 +20,7 @@ const ConfigOptions = () => {
         webRootDir: '.',
         assetSrcDir: 'src',
         assetDistDir: 'dist',
+        applyRevision: true,
 
         /**
          * CSS-related variables
@@ -38,8 +39,7 @@ const ConfigOptions = () => {
             files: {
                 main: {
                     srcPath: 'index.js',
-                    distFile: 'script.js',
-                    applyRevision: true
+                    distFile: 'script.js'
                 }
             },
             jsDir: 'js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -106,6 +106,8 @@ gulp.task('css:lint', () => gulp.src(`${pathBuilder.cssDistDir}/**/*.css`)
  */
 gulp.task('css:bundle', () => {
 
+    const { applyRevision } = config;
+
     const source = gulp.src(`${pathBuilder.scssSrcDir}/**/*.scss`)
         // stops watch from breaking on error
         .pipe(plumber(config.gulp.onError))
@@ -169,9 +171,14 @@ gulp.task('css:bundle', () => {
         .pipe(gulpif(config.docs.outputAssets,
             gulp.dest(pathBuilder.docsCssDistDir)
         ))
+        
+        // output minified file to destination CSS folder
+        .pipe(gulp.dest(pathBuilder.cssDistDir))
 
         // revision control for caching
-        .pipe(rev())
+        .pipe(gulpif(applyRevision,
+            rev()
+        ))
 
         // Output file-size
         .pipe(gulpif(config.misc.showFileSize,

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -106,8 +106,6 @@ gulp.task('css:lint', () => gulp.src(`${pathBuilder.cssDistDir}/**/*.css`)
  */
 gulp.task('css:bundle', () => {
 
-    const { applyRevision } = config;
-
     const source = gulp.src(`${pathBuilder.scssSrcDir}/**/*.scss`)
         // stops watch from breaking on error
         .pipe(plumber(config.gulp.onError))
@@ -176,7 +174,7 @@ gulp.task('css:bundle', () => {
         .pipe(gulp.dest(pathBuilder.cssDistDir))
 
         // revision control for caching
-        .pipe(gulpif(applyRevision,
+        .pipe(gulpif(config.applyRevision,
             rev()
         ))
 

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -171,7 +171,7 @@ gulp.task('css:bundle', () => {
         .pipe(gulpif(config.docs.outputAssets,
             gulp.dest(pathBuilder.docsCssDistDir)
         ))
-        
+
         // output minified file to destination CSS folder
         .pipe(gulp.dest(pathBuilder.cssDistDir))
 

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -95,7 +95,8 @@ gulp.task('scripts:bundle', () => {
 
     const bundleTasks = Object.keys(config.js.files).map(fileId => {
 
-        const { srcPath, distFile, applyRevision } = config.js.files[fileId];
+        const { srcPath, distFile } = config.js.files[fileId];
+        const { applyRevision } = config;
         const file = `${pathBuilder.jsSrcDir}/${srcPath}`;
 
         return browserify(file, { debug: config.isDev })
@@ -117,6 +118,7 @@ gulp.task('scripts:bundle', () => {
 
             .pipe(rename(distFile))
 
+            // output the unminified JS files
             .pipe(gulp.dest(pathBuilder.jsDistDir))
 
             // output the size of the unminified JS

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -96,7 +96,6 @@ gulp.task('scripts:bundle', () => {
     const bundleTasks = Object.keys(config.js.files).map(fileId => {
 
         const { srcPath, distFile } = config.js.files[fileId];
-        const { applyRevision } = config;
         const file = `${pathBuilder.jsSrcDir}/${srcPath}`;
 
         return browserify(file, { debug: config.isDev })
@@ -163,7 +162,7 @@ gulp.task('scripts:bundle', () => {
             ))
 
             // revision control for caching
-            .pipe(gulpif(applyRevision,
+            .pipe(gulpif(config.applyRevision,
                 rev()
             ))
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -197,6 +197,7 @@ describe('javascript config', () => {
         // Assert
         expect(config.js.files.main.distFile).toBe(distFile);
     });
+
 });
 
 describe('image config', () => {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -55,6 +55,21 @@ describe('environment config', () => {
         expect(config.assetDistDir).toBe(assetDistDir);
     });
 
+    it('apply revision should be true', () => {
+        expect(config.applyRevision).toBe(true);
+    });
+
+    it('apply revision can be updated', () => {
+        // Arrange
+        const applyRevision = false;
+
+        // Act
+        config.update({ applyRevision });
+
+        // Assert
+        expect(config.applyRevision).toBe(applyRevision);
+    });
+
 });
 
 describe('css config', () => {
@@ -182,22 +197,6 @@ describe('javascript config', () => {
         // Assert
         expect(config.js.files.main.distFile).toBe(distFile);
     });
-
-    it('apply revision should be true', () => {
-        expect(config.js.files.main.applyRevision).toBe(true);
-    });
-
-    it('apply revision can be updated', () => {
-        // Arrange
-        const applyRevision = false;
-
-        // Act
-        config.update({ js: { files: { main: { applyRevision } } } });
-
-        // Assert
-        expect(config.js.files.main.applyRevision).toBe(applyRevision);
-    });
-
 });
 
 describe('image config', () => {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -231,6 +231,7 @@ describe('image config', () => {
         // Assert
         expect(config.img.svgSpriteFilename).toBe(svgSpriteFilename);
     });
+
 });
 
 describe('imported assets config', () => {


### PR DESCRIPTION
Moved the applyRevision variable out of the JS-only config, also updated readme and unit tests.

Fixes #99.