### PR TITLE
v7.3.0 — Set `bail` argument to `true` only when run in production.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v7.3.0
+------------------------------
+*January 30, 2018*
+
+### Changed
+- Set `bail` argument to `true` only when run in production.
+
+
 v7.2.0
 ------------------------------
 *January 23, 2018*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -95,5 +95,6 @@ gulp.task('copy:assets', () =>
         dest: config.assetDistDir,
         verbose: config.importedAssets.verbose,
         logger: gutil.log
-    }).catch(config.gulp.onError)
+    })
+        .catch(config.gulp.onError)
 );

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -63,7 +63,7 @@ gulp.task('scripts:lint', () => gulp.src([`${pathBuilder.jsSrcDir}/**/*.js`, ...
 
 
 const jestTestRun = (args = {}) => jest.runCLI(
-    Object.assign({ bail: true }, args),
+    Object.assign({ bail: config.isProduction }, args),
     [path.resolve(process.cwd())]
 );
 


### PR DESCRIPTION
### Changed
- Set `bail` argument to `true` only when run in production.