### PR TITLE
v7.4.0 — Set `passWithNoTests` argument to `true` for all Jest test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.4.0
+------------------------------
+*January 30, 2018*
+
+### Changed
+- Set `passWithNoTests` argument to `true` for all Jest test runs to prevent error when there are no tests in the project.
+
+
 v7.3.0
 ------------------------------
 *January 30, 2018*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -62,10 +62,10 @@ gulp.task('scripts:lint', () => gulp.src([`${pathBuilder.jsSrcDir}/**/*.js`, ...
 );
 
 
-const jestTestRun = (args = {}) => jest.runCLI(
-    Object.assign({ bail: config.isProduction }, args),
-    [path.resolve(process.cwd())]
-);
+const jestTestRun = (args = {
+    bail: config.isProduction,
+    passWithNoTests: true
+}) => jest.runCLI(args, [path.resolve(process.cwd())]);
 
 /**
  * `scripts:test` Task


### PR DESCRIPTION
### Changed
- Set `passWithNoTests` argument to `true` for all Jest test runs to prevent error when there are no tests in the project.