### PR TITLE
v7.9.0 (CPD-11491) - Optional removal of console.log statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.8.0
+------------------------------
+*February 2, 2018*
+
+### Added
+- `stripDebug` option to `config.js` to allow the inclusion of console statements in production builds.
+
+### Changed
+- Jest rollback from v22.1.4 to v21.2.1.
+
 v7.7.0
 ------------------------------
 *January 30, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v7.9.0
 
 ### Added
 - `stripDebug` option to `config.js` to allow the inclusion of console statements in production builds.
+- `--noStripDebug` command line flag.
 
 ### Changed
 - Jest rollback from v22.1.4 to v21.2.1.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Gulp build tasks for use across Fozzie modules.
     - [Config object](#config-object)
     - [pathBuilder object](#pathbuilder-object)
 - [The Gulp Tasks](#the-gulp-tasks)
-  - [Development only tasks](#development-only-tasks)
+  - [Development-only tasks](#development-only-tasks)
 - [Config](#config)
   - [Other config](#other-config)
 - [Path Builder](#path-builder)
-- [Running the unit tests](running-the-unit-tests)
+- [Running the unit tests](#running-the-unit-tests)
 
 
 ## Setup
@@ -245,7 +245,7 @@ Runs the same tasks as [`watch`](#watch) as well as the following watch tasks.
 Runs the [`assemble`](#assemble) task when documentation files are changed.
 
 
-### Development only tasks
+### Development-only tasks
 
 - #### `docs`
 
@@ -392,7 +392,7 @@ Root dist directory for your assets.
 
 Type: `boolean`
 
-Default: true
+Default: `true`
 
 Will add a content hash to the JS and CSS filenames, generating a new filename if any of the file's contents have changed. This can be utilised to force the clients to get the latest version of an updated asset.
 
@@ -444,7 +444,9 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
   Type: `boolean`
 
-  Default is set to `false`, when set to true this will bundle a versioned css file e.g `'filename-[version].css'`.
+  Default: `false`
+
+  When set to `true` this will bundle a versioned css file e.g `'filename-[version].css'`.
 
 
 ### `js`
@@ -507,13 +509,17 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
   Type: `boolean`
 
-  Default is set to `false`, when set to true this will bundle a versioned JS file e.g `'filename-[version].js'`.
+  Default: `false`
+
+  When set to `true` this will bundle a versioned JS file e.g `'filename-[version].js'`.
 
 - #### `stripDebug`
 
   Type: `boolean`
 
-  Default is set to `true`. When set to false, this will prevent `console.log()` statements from being removed for production builds. **For non-production builds, this has no effect: you will still get debug statements even if you've set this to `true`.**
+  Default: `true`
+
+  When set to `false`, this will prevent `console.log()` statements from being removed for production builds. **For non-production builds, this has no effect: you will still get debug statements even if you've set this to `true`.**
 
 
 ### `img`
@@ -649,7 +655,7 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
   In which:
   - `path` is a string specifying the path within the relevant asset `src` folder of the asset to be copied.
   - `dest` is a string specifying that destination folder for the asset to be copied to, within the relevant asset `dist` folder.
-  - `revision` is a boolean such that if it is true, the asset will be [revision hashed](https://www.npmjs.com/package/gulp-rev) when copied to it’s destination.
+  - `revision` is a boolean such that if it is `true`, the asset will be [revision hashed](https://www.npmjs.com/package/gulp-rev) when copied to its destination.
 
   `path` and `dest` must always be defined for each asset you wish to copy.
 
@@ -732,13 +738,13 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
   Default: `''`
 
-  Applies a base path to asset URLs when publishing documentation to Github pages.  By default this is set to be an empty string.
+  Applies a base path to asset URLs when publishing documentation to Github pages. By default this is set to be an empty string.
 
 - #### `helpers`
 
   Type: `object`
 
-  Default: `{ }`
+  Default: `{}`
 
   Can pass in an object set of functions, which will be exposed in handlebars as helper functions in the documentation tasks when called using their object key.
 
@@ -786,7 +792,7 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
   Default: `1000`
 
-  Wait for a specified window of event-silence before sending any reload events.
+  Wait for a specified window of event-silence (in milliseconds) before sending any reload events.
 
 ### `misc`
 
@@ -836,7 +842,7 @@ The following options are also present in the config but cannot be overridden.
 
   Type: `boolean`
 
-  Set to the opposite value of `isProduction`
+  Set to the opposite value of `isProduction`.
 
 
 ## Path Builder

--- a/README.md
+++ b/README.md
@@ -304,7 +304,8 @@ Here is the outline of the configuration options, descriptions of each are below
         ],
         jsDir,
         lintPaths,
-        usePackageVersion
+        usePackageVersion,
+        stripDebug
     },
     img: {
         imgDir,
@@ -443,7 +444,7 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
   Type: `boolean`
 
-  Default is set to false, when set to true this will bundle a versioned css file e.g `'filename-[version].css'`.
+  Default is set to `false`, when set to true this will bundle a versioned css file e.g `'filename-[version].css'`.
 
 
 ### `js`
@@ -506,7 +507,13 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
   Type: `boolean`
 
-  Default is set to false, when set to true this will bundle a versioned JS file e.g `'filename-[version].js'`.
+  Default is set to `false`, when set to true this will bundle a versioned JS file e.g `'filename-[version].js'`.
+
+- #### `stripDebug`
+
+  Type: `boolean`
+
+  Default is set to `true`. When set to false, this will prevent `console.log()` statements from being removed for production builds. **For non-production builds, this has no effect: you will still get debug statements even if you've set this to `true`.**
 
 
 ### `img`

--- a/README.md
+++ b/README.md
@@ -519,8 +519,21 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
   Default: `true`
 
-  When set to `false`, this will prevent `console.log()` statements from being removed for production builds. **For non-production builds, this has no effect: you will still get debug statements even if you've set this to `true`.**
+  This can also be controlled using the `--noStripDebug` flag. When this flag is added, `console.log()` statements will not be removed for production builds.
 
+  #### Examples:
+
+  `gulp scripts:bundle --prod --noStripDebug`
+
+  This would generate the JS files as part of a production build, but would still include `console.log()` statements. Intended for QA releases.
+
+  `gulp scripts:bundle --prod`
+
+  This is a normal production build and would not include `console.log()` statements.
+
+  `gulp scripts:bundle --noStripDebug`
+
+  **For non-production builds, the flag has no effect: you will still get debug statements even if include the flag.**
 
 ### `img`
 

--- a/config.js
+++ b/config.js
@@ -45,7 +45,8 @@ const ConfigOptions = () => {
             },
             jsDir: 'js',
             lintPaths: [''],
-            usePackageVersion: false
+            usePackageVersion: false,
+            stripDebug: true
         },
 
         /**

--- a/config.js
+++ b/config.js
@@ -10,6 +10,7 @@ const ConfigOptions = () => {
     const isProduction = !!gutil.env.prod;
     const isDev = !isProduction;
     const envLog = isProduction ? 'production' : 'development';
+    const stripDebug = !gutil.env.noStripDebug;
 
     gutil.log(gutil.colors.yellow(`🐻  Running Gulp task for ${consumingPackageConfig.name}@${consumingPackageConfig.version} in ${gutil.colors.bold(envLog)} mode ${gutil.colors.gray(`(v${packageConfig.version})`)}`));
 
@@ -46,7 +47,7 @@ const ConfigOptions = () => {
             jsDir: 'js',
             lintPaths: [''],
             usePackageVersion: false,
-            stripDebug: true
+            stripDebug
         },
 
         /**

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "handlebars-helpers": "^0.10.0",
     "helper-markdown": "^1.0.0",
     "helper-md": "^0.2.2",
-    "jest-cli": "^22.1.4",
+    "jest-cli": "^21.2.1",
     "merge-stream": "^1.0.1",
     "postcss-assets": "^5.0.0",
     "postcss-reporter": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -135,7 +135,9 @@ gulp.task('scripts:bundle', () => {
 
             // if production build, rip out our console logs
             .pipe(gulpif(config.isProduction,
-                stripDebug()
+                () => {
+                    gulpif(config.js.stripDebug, stripDebug());
+                }
             ))
 
             // minify the bundle

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -134,10 +134,8 @@ gulp.task('scripts:bundle', () => {
             ))
 
             // if production build, rip out our console logs
-            .pipe(gulpif(config.isProduction,
-                () => {
-                    gulpif(config.js.stripDebug, stripDebug());
-                }
+            .pipe(gulpif(config.isProduction && config.js.stripDebug,
+                stripDebug()
             ))
 
             // minify the bundle

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -155,6 +155,17 @@ describe('css config', () => {
     it('`usePackageVersion` should be set to `false` by default', () => {
         expect(config.css.usePackageVersion).toBe(false);
     });
+
+    it('usePackageVersion can be updated', () => {
+        // Arrange
+        const usePackageVersion = true;
+
+        // Act
+        config.update({ css: { usePackageVersion } });
+
+        // Assert
+        expect(config.css.usePackageVersion).toBe(usePackageVersion);
+    });
 });
 
 describe('javascript config', () => {
@@ -172,6 +183,21 @@ describe('javascript config', () => {
 
         // Assert
         expect(config.js.files.main.srcPath).toBe(srcPath);
+    });
+
+    it('dist file should be set', () => {
+        expect(config.js.files.main.distFile).toBe('script.js');
+    });
+
+    it('dist file can be updated', () => {
+        // Arrange
+        const distFile = 'app.js';
+
+        // Act
+        config.update({ js: { files: { main: { distFile } } } });
+
+        // Assert
+        expect(config.js.files.main.distFile).toBe(distFile);
     });
 
     it('javascript directory should be set', () => {
@@ -204,27 +230,42 @@ describe('javascript config', () => {
         expect(config.js.lintPaths).toEqual(lintPaths);
     });
 
-    it('dist file should be set', () => {
-        expect(config.js.files.main.distFile).toBe('script.js');
-    });
-
-    it('dist file can be updated', () => {
-        // Arrange
-        const distFile = 'app.js';
-
-        // Act
-        config.update({ js: { files: { main: { distFile } } } });
-
-        // Assert
-        expect(config.js.files.main.distFile).toBe(distFile);
-    });
-
     it('`usePackageVersion` should exist', () => {
         expect(config.js.usePackageVersion).toBeDefined();
     });
 
     it('`usePackageVersion` should be set to `false` by default', () => {
         expect(config.js.usePackageVersion).toBe(false);
+    });
+
+    it('usePackageVersion can be updated', () => {
+        // Arrange
+        const usePackageVersion = true;
+
+        // Act
+        config.update({ js: { usePackageVersion } });
+
+        // Assert
+        expect(config.js.usePackageVersion).toBe(usePackageVersion);
+    });
+
+    it('`stripDebug` should exist', () => {
+        expect(config.js.stripDebug).toBeDefined();
+    });
+
+    it('`stripDebug` should be set to `true` by default', () => {
+        expect(config.js.stripDebug).toBe(true);
+    });
+
+    it('strip debug can be updated', () => {
+        // Arrange
+        const stripDebug = false;
+
+        // Act
+        config.update({ js: { stripDebug } });
+
+        // Assert
+        expect(config.js.stripDebug).toBe(stripDebug);
     });
 
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -2,19 +2,19 @@ const config = require('../config');
 
 describe('environment config', () => {
 
-    it('is production should be false', () => {
+    it('`isProduction` should be false', () => {
         expect(config.isProduction).toBe(false);
     });
 
-    it('is dev should be true', () => {
+    it('`isDev` should be true', () => {
         expect(config.isDev).toBe(true);
     });
 
-    it('web root directory should be true', () => {
+    it('`webRootDir` should be `.`', () => {
         expect(config.webRootDir).toBe('.');
     });
 
-    it('web root directory can be updated', () => {
+    it('`webRootDir` can be updated', () => {
         // Arrange
         const webRootDir = './';
 
@@ -25,11 +25,11 @@ describe('environment config', () => {
         expect(config.webRootDir).toBe(webRootDir);
     });
 
-    it('asset src directory should be set', () => {
+    it('`assetSrcDir` should be set', () => {
         expect(config.assetSrcDir).toBe('src');
     });
 
-    it('asset src directory can be updated', () => {
+    it('`assetSrcDir` can be updated', () => {
         // Arrange
         const assetSrcDir = 'source';
 
@@ -40,11 +40,11 @@ describe('environment config', () => {
         expect(config.assetSrcDir).toBe(assetSrcDir);
     });
 
-    it('asset dist directory should be set', () => {
+    it('`assetDistDir` should be set', () => {
         expect(config.assetDistDir).toBe('dist');
     });
 
-    it('asset dist directory can be updated', () => {
+    it('`assetDistDir` can be updated', () => {
         // Arrange
         const assetDistDir = 'distribution';
 
@@ -55,11 +55,11 @@ describe('environment config', () => {
         expect(config.assetDistDir).toBe(assetDistDir);
     });
 
-    it('apply revision should be true', () => {
+    it('`applyRevision` should be true', () => {
         expect(config.applyRevision).toBe(true);
     });
 
-    it('apply revision can be updated', () => {
+    it('`applyRevision` can be updated', () => {
         // Arrange
         const applyRevision = false;
 
@@ -88,11 +88,11 @@ describe('environment config', () => {
 
 describe('css config', () => {
 
-    it('scss directory should be set', () => {
+    it('`scssDir` should be set', () => {
         expect(config.css.scssDir).toBe('scss');
     });
 
-    it('scss directory can be updated', () => {
+    it('`scssDir` can be updated', () => {
         // Arrange
         const scssDir = 'sass';
 
@@ -103,11 +103,11 @@ describe('css config', () => {
         expect(config.css.scssDir).toBe(scssDir);
     });
 
-    it('css directory should be set', () => {
+    it('`cssDir` should be set', () => {
         expect(config.css.cssDir).toBe('css');
     });
 
-    it('css directory can be updated', () => {
+    it('`cssDir` can be updated', () => {
         // Arrange
         const cssDir = 'styles';
 
@@ -118,11 +118,11 @@ describe('css config', () => {
         expect(config.css.cssDir).toBe(cssDir);
     });
 
-    it('lint paths should be set', () => {
+    it('`lintPaths` should be set', () => {
         expect(config.css.lintPaths).toEqual(['']);
     });
 
-    it('lint paths can be updated', () => {
+    it('`lintPaths` can be updated', () => {
         // Arrange
         const lintPaths = ['./lint-me', '🦄'];
 
@@ -133,11 +133,11 @@ describe('css config', () => {
         expect(config.css.lintPaths).toEqual(lintPaths);
     });
 
-    it('sourcemaps should be true', () => {
+    it('`sourcemaps` should be true', () => {
         expect(config.css.sourcemaps).toBe(true);
     });
 
-    it('sourcemaps can be updated', () => {
+    it('`sourcemaps` can be updated', () => {
         // Arrange
         const sourcemaps = false;
 
@@ -156,7 +156,7 @@ describe('css config', () => {
         expect(config.css.usePackageVersion).toBe(false);
     });
 
-    it('usePackageVersion can be updated', () => {
+    it('`usePackageVersion` can be updated', () => {
         // Arrange
         const usePackageVersion = true;
 
@@ -170,11 +170,11 @@ describe('css config', () => {
 
 describe('javascript config', () => {
 
-    it('src path for bundle should be set', () => {
+    it('`srcPath` for bundle should be set', () => {
         expect(config.js.files.main.srcPath).toBe('index.js');
     });
 
-    it('src path can be updated', () => {
+    it('`srcPath` can be updated', () => {
         // Arrange
         const srcPath = 'app.js';
 
@@ -185,11 +185,11 @@ describe('javascript config', () => {
         expect(config.js.files.main.srcPath).toBe(srcPath);
     });
 
-    it('dist file should be set', () => {
+    it('`distFile` should be set', () => {
         expect(config.js.files.main.distFile).toBe('script.js');
     });
 
-    it('dist file can be updated', () => {
+    it('`distFile` can be updated', () => {
         // Arrange
         const distFile = 'app.js';
 
@@ -200,11 +200,11 @@ describe('javascript config', () => {
         expect(config.js.files.main.distFile).toBe(distFile);
     });
 
-    it('javascript directory should be set', () => {
+    it('`jsDir` should be set', () => {
         expect(config.js.jsDir).toBe('js');
     });
 
-    it('javascript directory can be updated', () => {
+    it('`jsDir` can be updated', () => {
         // Arrange
         const jsDir = 'scripts';
 
@@ -215,11 +215,11 @@ describe('javascript config', () => {
         expect(config.js.jsDir).toBe(jsDir);
     });
 
-    it('lint paths should be set', () => {
+    it('`lintPaths` should be set', () => {
         expect(config.js.lintPaths).toEqual(['']);
     });
 
-    it('lint paths can be updated', () => {
+    it('`lintPaths` can be updated', () => {
         // Arrange
         const lintPaths = ['./lint-me', '🐝'];
 
@@ -238,7 +238,7 @@ describe('javascript config', () => {
         expect(config.js.usePackageVersion).toBe(false);
     });
 
-    it('usePackageVersion can be updated', () => {
+    it('`usePackageVersion` can be updated', () => {
         // Arrange
         const usePackageVersion = true;
 
@@ -257,7 +257,7 @@ describe('javascript config', () => {
         expect(config.js.stripDebug).toBe(true);
     });
 
-    it('strip debug can be updated', () => {
+    it('`stripDebug` can be updated', () => {
         // Arrange
         const stripDebug = false;
 
@@ -272,11 +272,11 @@ describe('javascript config', () => {
 
 describe('image config', () => {
 
-    it('image directory should be set', () => {
+    it('`imgDir` should be set', () => {
         expect(config.img.imgDir).toBe('img');
     });
 
-    it('image directory can be updated', () => {
+    it('`imgDir` can be updated', () => {
         // Arrange
         const imgDir = 'images';
 
@@ -287,11 +287,11 @@ describe('image config', () => {
         expect(config.img.imgDir).toBe(imgDir);
     });
 
-    it('svg sprite filename should be set', () => {
+    it('`svgSpriteFilename` should be set', () => {
         expect(config.img.svgSpriteFilename).toBe('sprite.svg');
     });
 
-    it('svg sprite filename can be updated', () => {
+    it('`svgSpriteFilename` can be updated', () => {
         // Arrange
         const svgSpriteFilename = 'fairy.svg';
 
@@ -306,11 +306,11 @@ describe('image config', () => {
 
 describe('imported assets config', () => {
 
-    it('imported assets source glob should be set', () => {
+    it('`importedAssetsSrcGlob` should be set', () => {
         expect(config.importedAssets.importedAssetsSrcGlob).toBe('node_modules/@justeat/*/');
     });
 
-    it('imported assets source glob can be updated', () => {
+    it('`importedAssetsSrcGlob` can be updated', () => {
         // Arrange
         const importedAssetsSrcGlob = 'node_modules/*/';
 
@@ -321,11 +321,11 @@ describe('imported assets config', () => {
         expect(config.importedAssets.importedAssetsSrcGlob).toBe(importedAssetsSrcGlob);
     });
 
-    it('verbose should be true', () => {
+    it('`verbose` should be true', () => {
         expect(config.importedAssets.verbose).toBe(true);
     });
 
-    it('verbose can be updated', () => {
+    it('`verbose` can be updated', () => {
         // Arrange
         const verbose = false;
 
@@ -340,11 +340,11 @@ describe('imported assets config', () => {
 
 describe('service worker config', () => {
 
-    it('is enabled should be false', () => {
+    it('`isEnabled` should be false', () => {
         expect(config.sw.isEnabled).toBe(false);
     });
 
-    it('is enabled can be updated', () => {
+    it('`isEnabled` can be updated', () => {
         // Arrange
         const isEnabled = true;
 
@@ -355,11 +355,11 @@ describe('service worker config', () => {
         expect(config.sw.isEnabled).toBe(isEnabled);
     });
 
-    it('service worker directory should be set', () => {
+    it('`swDir` should be set', () => {
         expect(config.sw.swDir).toBe('sw');
     });
 
-    it('service worker directory can be updated', () => {
+    it('`swDir` can be updated', () => {
         // Arrange
         const swDir = 'service-worker';
 
@@ -370,11 +370,11 @@ describe('service worker config', () => {
         expect(config.sw.swDir).toBe(swDir);
     });
 
-    it('output filename should be set', () => {
+    it('`outputFile` should be set', () => {
         expect(config.sw.outputFile).toBe('service-worker.js');
     });
 
-    it('output filename can be updated', () => {
+    it('`outputFile` can be updated', () => {
         // Arrange
         const outputFile = 'sw.js';
 
@@ -385,11 +385,11 @@ describe('service worker config', () => {
         expect(config.sw.outputFile).toBe(outputFile);
     });
 
-    it('static file globs should be set', () => {
+    it('`staticFileGlobs` should be set', () => {
         expect(config.sw.staticFileGlobs).toEqual([]);
     });
 
-    it('static file globs can be updated', () => {
+    it('`staticFileGlobs` can be updated', () => {
         // Arrange
         const staticFileGlobs = ['./glob', '🛰'];
 
@@ -400,11 +400,11 @@ describe('service worker config', () => {
         expect(config.sw.staticFileGlobs).toEqual(staticFileGlobs);
     });
 
-    it('dynamic file regex should be set', () => {
+    it('`dynamicFileRegex` should be set', () => {
         expect(config.sw.dynamicFileRegex).toEqual([]);
     });
 
-    it('dynamic file regex can be updated', () => {
+    it('`dynamicFileRegex` can be updated', () => {
         // Arrange
         const dynamicFileRegex = ['regex', '🗡'];
 
@@ -415,11 +415,11 @@ describe('service worker config', () => {
         expect(config.sw.dynamicFileRegex).toEqual(dynamicFileRegex);
     });
 
-    it('dynamic file strategy should be set', () => {
+    it('`dynamicFileStrategy` should be set', () => {
         expect(config.sw.dynamicFileStrategy).toBe('cacheFirst');
     });
 
-    it('dynamic file strategy can be updated', () => {
+    it('`dynamicFileStrategy` can be updated', () => {
         // Arrange
         const dynamicFileStrategy = 'networkFirst';
 
@@ -430,11 +430,11 @@ describe('service worker config', () => {
         expect(config.sw.dynamicFileStrategy).toBe(dynamicFileStrategy);
     });
 
-    it('import scripts should be set', () => {
+    it('`importScripts` should be set', () => {
         expect(config.sw.importScripts).toEqual([]);
     });
 
-    it('import scripts can be updated', () => {
+    it('`importScripts` can be updated', () => {
         // Arrange
         const importScripts = ['script.js'];
 
@@ -445,11 +445,11 @@ describe('service worker config', () => {
         expect(config.sw.importScripts).toEqual(importScripts);
     });
 
-    it('cache id should be set', () => {
+    it('`cacheId` should be set', () => {
         expect(config.sw.cacheId).toBe('');
     });
 
-    it('cache id can be updated', () => {
+    it('`cacheId` can be updated', () => {
         // Arrange
         const cacheId = 'id-1';
 
@@ -463,11 +463,11 @@ describe('service worker config', () => {
 
 describe('copy config', () => {
 
-    it('copy javascript config should be set', () => {
+    it('copy js config should be set', () => {
         expect(config.copy.js).toEqual({});
     });
 
-    it('copy javascript config can be updated', () => {
+    it('copy js config can be updated', () => {
         // Arrange
         const js = {
             scripts: {
@@ -505,11 +505,11 @@ describe('copy config', () => {
         expect(config.copy.css).toEqual(css);
     });
 
-    it('copy image config should be set', () => {
+    it('copy img config should be set', () => {
         expect(config.copy.img).toEqual({});
     });
 
-    it('copy image config can be updated', () => {
+    it('copy img config can be updated', () => {
         // Arrange
         const img = {
             images: {
@@ -551,11 +551,11 @@ describe('copy config', () => {
 
 describe('documentation config', () => {
 
-    it('root directory should be set', () => {
+    it('`rootDir` should be set', () => {
         expect(config.docs.rootDir).toBe('./docs');
     });
 
-    it('root directory can be updated', () => {
+    it('`rootDir` can be updated', () => {
         // Arrange
         const rootDir = 'documentation';
 
@@ -566,11 +566,11 @@ describe('documentation config', () => {
         expect(config.docs.rootDir).toBe(rootDir);
     });
 
-    it('src directory should be set', () => {
+    it('`srcDir` should be set', () => {
         expect(config.docs.srcDir).toBe('src');
     });
 
-    it('src directory can be updated', () => {
+    it('`srcDir` can be updated', () => {
         // Arrange
         const srcDir = 'source';
 
@@ -581,11 +581,11 @@ describe('documentation config', () => {
         expect(config.docs.srcDir).toBe(srcDir);
     });
 
-    it('dist directory should be set', () => {
+    it('`distDir` should be set', () => {
         expect(config.docs.distDir).toBe('dist');
     });
 
-    it('dist directory can be updated', () => {
+    it('`distDir` can be updated', () => {
         // Arrange
         const distDir = 'distribution';
 
@@ -596,11 +596,11 @@ describe('documentation config', () => {
         expect(config.docs.distDir).toBe(distDir);
     });
 
-    it('asset directory should be set', () => {
+    it('`assetDir` should be set', () => {
         expect(config.docs.assetDir).toBe('assets/');
     });
 
-    it('asset directory can be updated', () => {
+    it('`assetDir` can be updated', () => {
         // Arrange
         const assetDir = 'assets-dir';
 
@@ -611,11 +611,11 @@ describe('documentation config', () => {
         expect(config.docs.assetDir).toBe(assetDir);
     });
 
-    it('template directory should be set', () => {
+    it('`templDir` should be set', () => {
         expect(config.docs.templDir).toBe('templates');
     });
 
-    it('template directory can be updated', () => {
+    it('`templDir` can be updated', () => {
         // Arrange
         const templDir = 'tmpl';
 
@@ -626,11 +626,11 @@ describe('documentation config', () => {
         expect(config.docs.templDir).toBe(templDir);
     });
 
-    it('data directory should be set', () => {
+    it('`dataDir` should be set', () => {
         expect(config.docs.dataDir).toBe('data');
     });
 
-    it('data directory can be updated', () => {
+    it('`dataDir` can be updated', () => {
         // Arrange
         const dataDir = 'data-dir';
 
@@ -641,11 +641,11 @@ describe('documentation config', () => {
         expect(config.docs.dataDir).toBe(dataDir);
     });
 
-    it('output assets should be false', () => {
+    it('`outputAssets` should be false', () => {
         expect(config.docs.outputAssets).toBe(false);
     });
 
-    it('output assets can be updated', () => {
+    it('`outputAssets` can be updated', () => {
         // Arrange
         const outputAssets = true;
 
@@ -656,11 +656,11 @@ describe('documentation config', () => {
         expect(config.docs.outputAssets).toBe(outputAssets);
     });
 
-    it('remote base should be set', () => {
+    it('`remoteBase` should be set', () => {
         expect(config.docs.remoteBase).toBe('');
     });
 
-    it('remote base can be updated', () => {
+    it('`remoteBase` can be updated', () => {
         // Arrange
         const remoteBase = 'remote';
 
@@ -672,18 +672,18 @@ describe('documentation config', () => {
     });
 
 
-    it('helpers should be an object', () => {
+    it('`helpers` should be an object', () => {
         expect(typeof config.docs.helpers).toBe('object');
     });
 });
 
 describe('fonts config', () => {
 
-    it('fonts directory should be set', () => {
+    it('`fontsDir` should be set', () => {
         expect(config.fonts.fontsDir).toBe('fonts');
     });
 
-    it('fonts directory can be updated', () => {
+    it('`fontsDir` can be updated', () => {
         // Arrange
         const fontsDir = 'text';
 
@@ -698,11 +698,11 @@ describe('fonts config', () => {
 
 describe('browserSync config', () => {
 
-    it('files should be set', () => {
+    it('`files` should be set', () => {
         expect(config.browserSync.files).toEqual([]);
     });
 
-    it('files can be updated', () => {
+    it('`files` can be updated', () => {
         // Arrange
         const files = ['/**/*'];
 
@@ -713,11 +713,11 @@ describe('browserSync config', () => {
         expect(config.browserSync.files).toBe(files);
     });
 
-    it('proxy should be set', () => {
+    it('`proxy` should be set', () => {
         expect(config.browserSync.proxy).toBe('');
     });
 
-    it('proxy can be updated', () => {
+    it('`proxy` can be updated', () => {
         // Arrange
         const proxy = 'localhost';
 
@@ -728,11 +728,11 @@ describe('browserSync config', () => {
         expect(config.browserSync.proxy).toBe(proxy);
     });
 
-    it('reload debounce should be set', () => {
+    it('`reloadDebounce` should be set', () => {
         expect(config.browserSync.reloadDebounce).toBe(1000);
     });
 
-    it('reload debounce can be updated', () => {
+    it('`reloadDebounce` can be updated', () => {
         // Arrange
         const reloadDebounce = 9001;
 
@@ -747,11 +747,11 @@ describe('browserSync config', () => {
 
 describe('miscellaneous config', () => {
 
-    it('show file size should be true', () => {
+    it('`showFileSize` should be true', () => {
         expect(config.misc.showFileSize).toBe(true);
     });
 
-    it('show file size can be updated', () => {
+    it('`showFileSize`can be updated', () => {
         // Arrange
         const showFileSize = false;
 
@@ -762,11 +762,11 @@ describe('miscellaneous config', () => {
         expect(config.misc.showFileSize).toBe(showFileSize);
     });
 
-    it('show files should be true', () => {
+    it('`showFiles` should be true', () => {
         expect(config.misc.showFiles).toBe(true);
     });
 
-    it('show files can be updated', () => {
+    it('`showFiles` can be updated', () => {
         // Arrange
         const showFiles = false;
 
@@ -780,11 +780,11 @@ describe('miscellaneous config', () => {
 
 describe('gulp config', () => {
 
-    it('change event should be a function', () => {
+    it('`changeEvent` should be a function', () => {
         expect(typeof config.gulp.changeEvent).toBe('function');
     });
 
-    it('change event can be updated', () => {
+    it('`changeEvent` can be updated', () => {
         // Arrange
         const changeEvent = () => 'changed!';
 
@@ -795,11 +795,11 @@ describe('gulp config', () => {
         expect(config.gulp.changeEvent).toBe(changeEvent);
     });
 
-    it('on error should be a function', () => {
+    it('`onError` should be a function', () => {
         expect(typeof config.gulp.onError).toBe('function');
     });
 
-    it('on error can be updated', () => {
+    it('`onError` can be updated', () => {
         // Arrange
         const onError = () => 'error!';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.37"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.37.tgz#2da1dd3b1b57bfdea777ddc378df7cd12fe40171"
-  dependencies:
-    chalk "^2.0.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
-
 "@browserify/acorn5-object-spread@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@browserify/acorn5-object-spread/-/acorn5-object-spread-5.0.1.tgz#92e9b37f97beac9ec429a3cc479ded380297540c"
@@ -54,10 +46,6 @@
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.6.0.tgz#383f456b26bc96c7889f0332079f4358b16c58dc"
 
-"@types/node@*":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
-
 JSONStream@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -87,11 +75,11 @@ accepts@1.3.3, accepts@~1.3.3:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
-acorn-globals@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
+acorn-globals@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
   dependencies:
-    acorn "^5.0.0"
+    acorn "^4.0.4"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -99,7 +87,7 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@5.X, acorn@^5.0.0, acorn@^5.1.2, acorn@^5.2.1:
+acorn@5.X, acorn@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
 
@@ -107,7 +95,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3:
+acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
@@ -136,15 +124,6 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.3.0:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
 ajv@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
@@ -153,6 +132,15 @@ ajv@^5.2.0:
     fast-deep-equal "^1.0.0"
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -949,11 +937,7 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
@@ -1148,12 +1132,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.1.0.tgz#7fae6f655fffe77e818a8c2868c754a42463fdfd"
+babel-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-21.2.0.tgz#2ce059519a9374a2c46f2455b6fbef5ad75d863e"
   dependencies:
-    babel-plugin-istanbul "^4.1.5"
-    babel-preset-jest "^22.1.0"
+    babel-plugin-istanbul "^4.0.0"
+    babel-preset-jest "^21.2.0"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -1167,7 +1151,7 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-istanbul@^4.1.5:
+babel-plugin-istanbul@^4.0.0:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
@@ -1175,9 +1159,9 @@ babel-plugin-istanbul@^4.1.5:
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
-babel-plugin-jest-hoist@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.1.0.tgz#c1281dd7887d77a1711dc760468c3b8285dde9ee"
+babel-plugin-jest-hoist@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1444,11 +1428,11 @@ babel-preset-env@1.6.1:
     invariant "^2.2.2"
     semver "^5.3.0"
 
-babel-preset-jest@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.1.0.tgz#ff4e704102f9642765e2254226050561d8942ec9"
+babel-preset-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
   dependencies:
-    babel-plugin-jest-hoist "^22.1.0"
+    babel-plugin-jest-hoist "^21.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@6.26.0, babel-register@^6.26.0:
@@ -2015,18 +1999,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
-
 boxen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
@@ -2097,10 +2069,6 @@ browser-pack@^6.0.1:
     defined "^1.0.0"
     through2 "^2.0.0"
     umd "^3.0.0"
-
-browser-process-hrtime@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
 
 browser-resolve@^1.11.0, browser-resolve@^1.11.2, browser-resolve@^1.7.0:
   version "1.11.2"
@@ -2698,14 +2666,6 @@ cliui@^3.0.3, cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-cliui@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
-
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -3224,12 +3184,6 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
-
 crypto-browserify@^3.0.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.11.0.tgz#3652a0906ab9b2a7e0c3ce66a408e957a2485522"
@@ -3744,7 +3698,7 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-detect-newline@2.X, detect-newline@^2.1.0:
+detect-newline@2.X:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
@@ -3823,10 +3777,6 @@ domelementtype@1, domelementtype@^1.3.0:
 domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-
-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.0.tgz#81fe5df81b3f057052cde3a9fa9bf536a85b9ab0"
 
 domhandler@^2.3.0:
   version "2.4.1"
@@ -4107,6 +4057,12 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+errno@^0.1.4:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
+  dependencies:
+    prr "~1.0.1"
+
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -4192,7 +4148,7 @@ escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.9.0:
+escodegen@^1.6.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
   dependencies:
@@ -4481,10 +4437,6 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
-exit@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-
 exorcist@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/exorcist/-/exorcist-1.0.0.tgz#ac16ca162a0c55adee24b601f8b0e6e77bf34e8b"
@@ -4590,16 +4542,16 @@ expand@^0.4.3:
     lazy-cache "^2.0.1"
     regex-flags "^0.1.0"
 
-expect@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-22.1.0.tgz#f8f9b019ab275d859cbefed531fbaefe8972431d"
+expect@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-21.2.1.tgz#003ac2ac7005c3c29e73b38a272d4afadd6d1d7b"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^22.1.0"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^22.1.0"
-    jest-message-util "^22.1.0"
-    jest-regex-util "^22.1.0"
+    jest-diff "^21.2.1"
+    jest-get-type "^21.2.0"
+    jest-matcher-utils "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-regex-util "^21.2.0"
 
 export-files@^2.1.1:
   version "2.1.1"
@@ -4630,7 +4582,7 @@ extend-shallow@^3.0.0:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -4977,14 +4929,6 @@ fork-stream@^0.0.4:
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
-form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
@@ -5893,23 +5837,12 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 has-ansi@^0.1.0:
   version "0.1.0"
@@ -6040,15 +5973,6 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
 helper-cache@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/helper-cache/-/helper-cache-0.7.2.tgz#024562c4b4b8b2ab2ab531d00be16ec496518b90"
@@ -6097,10 +6021,6 @@ hmac-drbg@^1.0.0:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-
-hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -6188,14 +6108,6 @@ http-signature@~1.1.0:
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
   dependencies:
     assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  dependencies:
-    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
@@ -6288,13 +6200,6 @@ immutable@^3.7.6:
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
-
-import-local@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
-  dependencies:
-    pkg-dir "^2.0.0"
-    resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -6683,10 +6588,6 @@ is-function-x@^3.2.0, is-function-x@^3.3.0:
     replace-comments-x "^2.0.0"
     to-boolean-x "^1.0.1"
     to-string-tag-x "^1.4.2"
-
-is-generator-fn@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
 
 is-generator@^1.0.3:
   version "1.0.3"
@@ -7078,7 +6979,7 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.1.14:
+istanbul-api@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
   dependencies:
@@ -7094,7 +6995,7 @@ istanbul-api@^1.1.14:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.1.1:
+istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
@@ -7104,7 +7005,7 @@ istanbul-lib-hook@^1.1.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.8.0, istanbul-lib-instrument@^1.9.1:
+istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
   dependencies:
@@ -7125,17 +7026,7 @@ istanbul-lib-report@^1.1.2:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz#a6fe1acba8ce08eebc638e572e294d267008aa0c"
-  dependencies:
-    debug "^2.6.3"
-    istanbul-lib-coverage "^1.1.1"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
-
-istanbul-lib-source-maps@^1.2.2:
+istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
   dependencies:
@@ -7158,249 +7049,224 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jest-changed-files@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.1.4.tgz#1f7844bcb739dec07e5899a633c0cb6d5069834e"
+jest-changed-files@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.1.4.tgz#0fe9f3ac881b0cdc00227114c58583a2ebefcc04"
+jest-cli@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.2.1.tgz#9c528b6629d651911138d228bdb033c157ec8c00"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
-    exit "^0.1.2"
     glob "^7.1.2"
     graceful-fs "^4.1.11"
-    import-local "^1.0.0"
     is-ci "^1.0.10"
-    istanbul-api "^1.1.14"
-    istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-instrument "^1.8.0"
-    istanbul-lib-source-maps "^1.2.1"
-    jest-changed-files "^22.1.4"
-    jest-config "^22.1.4"
-    jest-environment-jsdom "^22.1.4"
-    jest-get-type "^22.1.0"
-    jest-haste-map "^22.1.0"
-    jest-message-util "^22.1.0"
-    jest-regex-util "^22.1.0"
-    jest-resolve-dependencies "^22.1.0"
-    jest-runner "^22.1.4"
-    jest-runtime "^22.1.4"
-    jest-snapshot "^22.1.2"
-    jest-util "^22.1.4"
-    jest-worker "^22.1.0"
+    istanbul-api "^1.1.1"
+    istanbul-lib-coverage "^1.0.1"
+    istanbul-lib-instrument "^1.4.2"
+    istanbul-lib-source-maps "^1.1.0"
+    jest-changed-files "^21.2.0"
+    jest-config "^21.2.1"
+    jest-environment-jsdom "^21.2.1"
+    jest-haste-map "^21.2.0"
+    jest-message-util "^21.2.1"
+    jest-regex-util "^21.2.0"
+    jest-resolve-dependencies "^21.2.0"
+    jest-runner "^21.2.1"
+    jest-runtime "^21.2.1"
+    jest-snapshot "^21.2.1"
+    jest-util "^21.2.1"
     micromatch "^2.3.11"
-    node-notifier "^5.1.2"
-    realpath-native "^1.0.0"
-    rimraf "^2.5.4"
+    node-notifier "^5.0.2"
+    pify "^3.0.0"
     slash "^1.0.0"
     string-length "^2.0.0"
     strip-ansi "^4.0.0"
     which "^1.2.12"
-    yargs "^10.0.3"
+    worker-farm "^1.3.1"
+    yargs "^9.0.0"
 
-jest-config@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.1.4.tgz#075ffacce83c3e38cf85b1b9ba0d21bd3ee27ad0"
+jest-config@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
   dependencies:
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^22.1.4"
-    jest-environment-node "^22.1.4"
-    jest-get-type "^22.1.0"
-    jest-jasmine2 "^22.1.4"
-    jest-regex-util "^22.1.0"
-    jest-resolve "^22.1.4"
-    jest-util "^22.1.4"
-    jest-validate "^22.1.2"
-    pretty-format "^22.1.0"
+    jest-environment-jsdom "^21.2.1"
+    jest-environment-node "^21.2.1"
+    jest-get-type "^21.2.0"
+    jest-jasmine2 "^21.2.1"
+    jest-regex-util "^21.2.0"
+    jest-resolve "^21.2.0"
+    jest-util "^21.2.1"
+    jest-validate "^21.2.1"
+    pretty-format "^21.2.1"
 
-jest-diff@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.1.0.tgz#0fad9d96c87b453896bf939df3dc8aac6919ac38"
+jest-diff@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^22.1.0"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
 
-jest-docblock@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.1.0.tgz#3fe5986d5444cbcb149746eb4b07c57c5a464dfd"
+jest-docblock@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+
+jest-environment-jsdom@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz#38d9980c8259b2a608ec232deee6289a60d9d5b4"
   dependencies:
-    detect-newline "^2.1.0"
+    jest-mock "^21.2.0"
+    jest-util "^21.2.1"
+    jsdom "^9.12.0"
 
-jest-environment-jsdom@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.1.4.tgz#704518ce8375f7ec5de048d1e9c4268b08a03e00"
+jest-environment-node@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
   dependencies:
-    jest-mock "^22.1.0"
-    jest-util "^22.1.4"
-    jsdom "^11.5.1"
+    jest-mock "^21.2.0"
+    jest-util "^21.2.1"
 
-jest-environment-node@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.1.4.tgz#0f2946e8f8686ce6c5d8fa280ce1cd8d58e869eb"
-  dependencies:
-    jest-mock "^22.1.0"
-    jest-util "^22.1.4"
+jest-get-type@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
 
-jest-get-type@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.1.0.tgz#4e90af298ed6181edc85d2da500dbd2753e0d5a9"
-
-jest-haste-map@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.1.0.tgz#1174c6ff393f9818ebf1163710d8868b5370da2a"
+jest-haste-map@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-21.2.0.tgz#1363f0a8bb4338f24f001806571eff7a4b2ff3d8"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^22.1.0"
-    jest-worker "^22.1.0"
+    jest-docblock "^21.2.0"
     micromatch "^2.3.11"
     sane "^2.0.0"
+    worker-farm "^1.3.1"
 
-jest-jasmine2@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.1.4.tgz#cada0baf50a220c616a9575728b80d4ddedebe8b"
+jest-jasmine2@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz#9cc6fc108accfa97efebce10c4308548a4ea7592"
   dependencies:
-    callsites "^2.0.0"
     chalk "^2.0.1"
-    co "^4.6.0"
-    expect "^22.1.0"
+    expect "^21.2.1"
     graceful-fs "^4.1.11"
-    is-generator-fn "^1.0.0"
-    jest-diff "^22.1.0"
-    jest-matcher-utils "^22.1.0"
-    jest-message-util "^22.1.0"
-    jest-snapshot "^22.1.2"
-    source-map-support "^0.5.0"
+    jest-diff "^21.2.1"
+    jest-matcher-utils "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-snapshot "^21.2.1"
+    p-cancelable "^0.3.0"
 
-jest-leak-detector@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.1.0.tgz#08376644cee07103da069baac19adb0299b772c2"
-  dependencies:
-    pretty-format "^22.1.0"
-
-jest-matcher-utils@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.1.0.tgz#e164665b5d313636ac29f7f6fe9ef0a6ce04febc"
+jest-matcher-utils@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^22.1.0"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
 
-jest-message-util@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.1.0.tgz#51ba0794cb6e579bfc4e9adfac452f9f1a0293fc"
+jest-message-util@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.2.1.tgz#bfe5d4692c84c827d1dcf41823795558f0a1acbe"
   dependencies:
-    "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
     micromatch "^2.3.11"
     slash "^1.0.0"
-    stack-utils "^1.0.1"
 
-jest-mock@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.1.0.tgz#87ec21c0599325671c9a23ad0e05c86fb5879b61"
+jest-mock@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
 
-jest-regex-util@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.1.0.tgz#5daf2fe270074b6da63e5d85f1c9acc866768f53"
+jest-regex-util@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
 
-jest-resolve-dependencies@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz#340e4139fb13315cd43abc054e6c06136be51e31"
+jest-resolve-dependencies@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz#9e231e371e1a736a1ad4e4b9a843bc72bfe03d09"
   dependencies:
-    jest-regex-util "^22.1.0"
+    jest-regex-util "^21.2.0"
 
-jest-resolve@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.1.4.tgz#72b9b371eaac48f84aad4ad732222ffe37692602"
+jest-resolve@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-21.2.0.tgz#068913ad2ba6a20218e5fd32471f3874005de3a6"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
+    is-builtin-module "^1.0.0"
 
-jest-runner@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.1.4.tgz#e039039110cb1b31febc0f99e349bf7c94304a2f"
+jest-runner@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-21.2.1.tgz#194732e3e518bfb3d7cbfc0fd5871246c7e1a467"
   dependencies:
-    exit "^0.1.2"
-    jest-config "^22.1.4"
-    jest-docblock "^22.1.0"
-    jest-haste-map "^22.1.0"
-    jest-jasmine2 "^22.1.4"
-    jest-leak-detector "^22.1.0"
-    jest-message-util "^22.1.0"
-    jest-runtime "^22.1.4"
-    jest-util "^22.1.4"
-    jest-worker "^22.1.0"
+    jest-config "^21.2.1"
+    jest-docblock "^21.2.0"
+    jest-haste-map "^21.2.0"
+    jest-jasmine2 "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-runtime "^21.2.1"
+    jest-util "^21.2.1"
+    pify "^3.0.0"
     throat "^4.0.0"
+    worker-farm "^1.3.1"
 
-jest-runtime@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.1.4.tgz#1474d9f5cda518b702e0b25a17d4ef3fc563a20c"
+jest-runtime@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-21.2.1.tgz#99dce15309c670442eee2ebe1ff53a3cbdbbb73e"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^22.1.0"
-    babel-plugin-istanbul "^4.1.5"
+    babel-jest "^21.2.0"
+    babel-plugin-istanbul "^4.0.0"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
-    exit "^0.1.2"
     graceful-fs "^4.1.11"
-    jest-config "^22.1.4"
-    jest-haste-map "^22.1.0"
-    jest-regex-util "^22.1.0"
-    jest-resolve "^22.1.4"
-    jest-util "^22.1.4"
+    jest-config "^21.2.1"
+    jest-haste-map "^21.2.0"
+    jest-regex-util "^21.2.0"
+    jest-resolve "^21.2.0"
+    jest-util "^21.2.1"
     json-stable-stringify "^1.0.1"
     micromatch "^2.3.11"
-    realpath-native "^1.0.0"
     slash "^1.0.0"
     strip-bom "3.0.0"
     write-file-atomic "^2.1.0"
-    yargs "^10.0.3"
+    yargs "^9.0.0"
 
-jest-snapshot@^22.1.2:
-  version "22.1.2"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.1.2.tgz#b270cf6e3098f33aceeafda02b13eb0933dc6139"
+jest-snapshot@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
   dependencies:
     chalk "^2.0.1"
-    jest-diff "^22.1.0"
-    jest-matcher-utils "^22.1.0"
+    jest-diff "^21.2.1"
+    jest-matcher-utils "^21.2.1"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^22.1.0"
+    pretty-format "^21.2.1"
 
-jest-util@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.1.4.tgz#ac8cbd43ee654102f1941f3f0e9d1d789a8b6a9b"
+jest-util@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-21.2.1.tgz#a274b2f726b0897494d694a6c3d6a61ab819bb78"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
-    is-ci "^1.0.10"
-    jest-message-util "^22.1.0"
-    jest-validate "^22.1.2"
+    jest-message-util "^21.2.1"
+    jest-mock "^21.2.0"
+    jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
-jest-validate@^22.1.2:
-  version "22.1.2"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.1.2.tgz#c3b06bcba7bd9a850919fe336b5f2a8c3a239404"
+jest-validate@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^22.1.0"
+    jest-get-type "^21.2.0"
     leven "^2.1.0"
-    pretty-format "^22.1.0"
-
-jest-worker@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.1.0.tgz#0987832fe58fbdc205357f4c19b992446368cafb"
-  dependencies:
-    merge-stream "^1.0.1"
+    pretty-format "^21.2.1"
 
 jpegtran-bin@^3.0.0:
   version "3.2.0"
@@ -7451,33 +7317,28 @@ jschardet@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.4.2.tgz#2aa107f142af4121d145659d44f50830961e699a"
 
-jsdom@^11.5.1:
-  version "11.5.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.5.1.tgz#5df753b8d0bca20142ce21f4f6c039f99a992929"
+jsdom@^9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
   dependencies:
     abab "^1.0.3"
-    acorn "^5.1.2"
-    acorn-globals "^4.0.0"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
     array-equal "^1.0.0"
-    browser-process-hrtime "^0.1.2"
     content-type-parser "^1.0.1"
     cssom ">= 0.3.2 < 0.4.0"
     cssstyle ">= 0.2.37 < 0.3.0"
-    domexception "^1.0.0"
-    escodegen "^1.9.0"
+    escodegen "^1.6.1"
     html-encoding-sniffer "^1.0.1"
-    left-pad "^1.2.0"
-    nwmatcher "^1.4.3"
-    parse5 "^3.0.2"
-    pn "^1.0.0"
-    request "^2.83.0"
-    request-promise-native "^1.0.3"
+    nwmatcher ">= 1.3.9 < 2.0.0"
+    parse5 "^1.5.1"
+    request "^2.79.0"
     sax "^1.2.1"
     symbol-tree "^3.2.1"
-    tough-cookie "^2.3.3"
-    webidl-conversions "^4.0.2"
+    tough-cookie "^2.3.2"
+    webidl-conversions "^4.0.0"
     whatwg-encoding "^1.0.1"
-    whatwg-url "^6.3.0"
+    whatwg-url "^4.3.0"
     xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
@@ -7685,10 +7546,6 @@ lcid@^1.0.0:
 lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-
-left-pad@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
 
 leven@^2.1.0:
   version "2.1.0"
@@ -8070,10 +7927,6 @@ lodash.restparam@^3.0.0:
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
-
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
 lodash.template@^3.0.0:
   version "3.6.2"
@@ -8554,21 +8407,11 @@ mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
-
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.7:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
-
-mime-types@~2.1.17:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
-  dependencies:
-    mime-db "~1.30.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -8818,7 +8661,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.1.2:
+node-notifier@^5.0.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
   dependencies:
@@ -9007,11 +8850,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nwmatcher@^1.4.3:
+"nwmatcher@>= 1.3.9 < 2.0.0":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -9469,11 +9312,9 @@ parse-repo@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
 
-parse5@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
+parse5@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
 parseqs@0.0.5:
   version "0.0.5"
@@ -9605,10 +9446,6 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -9636,12 +9473,6 @@ pkg-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
   dependencies:
     find-up "^1.0.0"
-
-pkg-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
-  dependencies:
-    find-up "^2.1.0"
 
 pkg-store@^0.2.2:
   version "0.2.2"
@@ -9676,10 +9507,6 @@ pluralize@^4.0.0:
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
-
-pn@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
 portscanner@2.1.1:
   version "2.1.1"
@@ -10067,9 +9894,9 @@ pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
 
-pretty-format@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.1.0.tgz#2277605b40ed4529ae4db51ff62f4be817647914"
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -10124,6 +9951,10 @@ proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -10146,10 +9977,6 @@ punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
-
 q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
@@ -10161,10 +9988,6 @@ qs@6.2.1:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 query-string@^4.1.0:
   version "4.3.4"
@@ -10404,12 +10227,6 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
-
-realpath-native@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
-  dependencies:
-    util.promisify "^1.0.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -10667,20 +10484,6 @@ repo-utils@^0.3.6, repo-utils@^0.3.7:
     parse-github-url "^0.3.2"
     project-name "^0.2.6"
 
-request-promise-core@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
-  dependencies:
-    lodash "^4.13.1"
-
-request-promise-native@^1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
-  dependencies:
-    request-promise-core "1.1.1"
-    stealthy-require "^1.1.0"
-    tough-cookie ">=2.3.3"
-
 request@2, request@2.81.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -10707,33 +10510,6 @@ request@2, request@2.81.0, request@^2.79.0, request@^2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
-
-request@^2.83.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
 
 require-coercible-to-string-x@^1.0.0:
   version "1.0.0"
@@ -10779,12 +10555,6 @@ requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-resolve-cwd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
-  dependencies:
-    resolve-from "^3.0.0"
-
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
@@ -10802,10 +10572,6 @@ resolve-dir@^1.0.0:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-
-resolve-from@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -11282,12 +11048,6 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
-  dependencies:
-    hoek "4.x.x"
-
 socket.io-adapter@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz#2a805e8a14d6372124dd9159ad4502f8cb07f06b"
@@ -11377,12 +11137,6 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.1.tgz#72291517d1fd0cb9542cee6c27520884b5da1a07"
-  dependencies:
-    source-map "^0.6.0"
-
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -11407,7 +11161,7 @@ source-map@^0.4.2, source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -11503,10 +11257,6 @@ stable@~0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
 
-stack-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
-
 stat-mode@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
@@ -11531,10 +11281,6 @@ stdout-stream@^1.4.0:
   resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
   dependencies:
     readable-stream "^2.0.1"
-
-stealthy-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 stream-browserify@^2.0.0:
   version "2.0.1"
@@ -11659,7 +11405,7 @@ stringify-entities@^1.0.1:
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -12349,7 +12095,7 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
+tough-cookie@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
@@ -12361,11 +12107,9 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-tr46@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  dependencies:
-    punycode "^2.1.0"
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
 tree-kill@^1.1.0:
   version "1.2.0"
@@ -12746,7 +12490,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util.promisify@^1.0.0, util.promisify@~1.0.0:
+util.promisify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
   dependencies:
@@ -12770,10 +12514,6 @@ uuid@3.1.0, uuid@^3.0.0:
 uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
-uuid@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 uws@~0.14.4:
   version "0.14.5"
@@ -13011,7 +12751,11 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+
+webidl-conversions@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -13021,13 +12765,12 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-url@^6.3.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+whatwg-url@^4.3.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
   dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.0"
-    webidl-conversions "^4.0.1"
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whet.extend@~0.9.9:
   version "0.9.9"
@@ -13107,6 +12850,13 @@ wordwrap@0.0.2, wordwrap@~0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+worker-farm@^1.3.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.2.tgz#32b312e5dc3d5d45d79ef44acc2587491cd729ae"
+  dependencies:
+    errno "^0.1.4"
+    xtend "^4.0.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -13205,7 +12955,7 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@8.1.0, yargs-parser@^8.1.0:
+yargs-parser@8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
   dependencies:
@@ -13229,6 +12979,12 @@ yargs-parser@^5.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   dependencies:
     camelcase "^3.0.0"
+
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs@3.29.0:
   version "3.29.0"
@@ -13259,23 +13015,6 @@ yargs@6.4.0:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^4.1.0"
-
-yargs@^10.0.3:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.1.tgz#5fe1ea306985a099b33492001fa19a1e61efe285"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^8.1.0"
 
 yargs@^4.8.0:
   version "4.8.1"
@@ -13313,6 +13052,24 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yargs@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-9.0.1.tgz#52acc23feecac34042078ee78c0c007f5085db4c"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Added a value to the `config.js` that can override the removal of console.log() statements that would usually happen automatically for production builds.

Had to revert Jest to 21.2.1 as it was causing problems.