### PR TITLE
CPD-1653: Fixed output logger file location and added logger to the d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.13.0
+------------------------------
+*March 7, 2018*
+
+### Changed
+- Default gulp tasks so that the logger file is created when gulp is run.
+- Updated the pathBuilder `jsErrorLoggerDir` property to `assetDistDir` so it outputs in the correct directory.
+
 v7.12.0
 ------------------------------
 *February 16, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v7.13.0
 ------------------------------
-*March 7, 2018*
+*March 8, 2018*
 
 ### Changed
 - Default gulp tasks so that the logger file is created when gulp is run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v7.13.0
 ### Changed
 - Default gulp tasks so that the logger file is created when gulp is run.
 - Updated the pathBuilder `jsErrorLoggerDir` property to `assetDistDir` so it outputs in the correct directory.
+- Updated `pathBuilder` unit tests.
 
 v7.12.0
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -178,12 +178,9 @@ Runs the following tasks
   - Add hashed version to file name
   - Output bundle to the dist directory
   
-### `logger-file`
+### `logger:createFile`
   
-Runs the following tasks
-
-- #### `logger-file:logger-file-create`
-  Add the server-side file required for the errorLogger to be inserted into the filesystem.
+Adds the server-side file required for the errorLogger to be inserted into the filesystem.
 
 ### `images`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.12.0",
+  "version": "7.13.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/pathBuilder.js
+++ b/pathBuilder.js
@@ -14,7 +14,7 @@ const buildPaths = config => {
         jsSrcDir: `${config.assetSrcDir}/${config.js.jsDir}`,
         jsDistDir: `${config.assetDistDir}/${config.js.jsDir}`,
 
-        jsErrorLoggerDir: `${config.webRootDir}/${config.logger.dir}`,
+        jsErrorLoggerDir: `${config.assetDistDir}/${config.logger.dir}`,
 
         imgSrcDir: `${config.assetSrcDir}/${config.img.imgDir}`,
         imgDistDir: `${config.assetDistDir}/${config.img.imgDir}`,

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -14,6 +14,7 @@ gulp.task('default', callback => {
     runSequence(
         ['copy:fonts', 'images'],
         ['css', 'scripts'],
+        ['logger:createFile'],
         ...config.sw.isEnabled ? ['service-worker'] : [],
         callback
     );

--- a/test/pathBuilder.test.js
+++ b/test/pathBuilder.test.js
@@ -34,7 +34,7 @@ describe('javascript paths', () => {
 
 describe('`logger` path', () => {
     it('`jsErrorLoggerSubDir` path should be correct', () => {
-        expect(pathBuilder.jsErrorLoggerDir).toBe('./js/shared');
+        expect(pathBuilder.jsErrorLoggerDir).toBe('dist/js/shared');
     });
 });
 


### PR DESCRIPTION
Changes here mean that when we run Gulp within OrderWeb or GlobalWeb the logger file is created in the correct place. e.g. `wwwroot/gw/` or `wwwroot/ow/`.