### PR TITLE
v7.15.0 - Adding fix property to linting task to autofix issues that it can

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ jspm_packages
 
 # OS or Editor folders
 .idea
+
+.yalc
+yalc.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.15.0
+------------------------------
+*April 3, 2018*
+
+### Added
+- ESLint flag for automatically fixing ESLint rule violations.  Will now fix a number of issues in-line when the lint task is run.
+  For more info, check out the [fix rule in the ESLint docs](https://eslint.org/docs/user-guide/command-line-interface#--fix) and to see a list of the rules this will auto-fix, [see the ESLint rule list](https://eslint.org/docs/rules/).
+
+### Updated
+- `.gitignore` updated to exclude yalc config files
+
+
 v7.14.0
 ------------------------------
 *March 26, 2018*

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Runs the following tasks
 
 - #### `scripts:lint`
 
-  Lint all JavaScript in the source directory.
+  Lint all JavaScript in the source directory.  This task will also attempt to automatically fix any rules via the [ESLint `--fix` flag](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
 - #### `scripts:test`
 
@@ -177,9 +177,9 @@ Runs the following tasks
   - Minify the JavaScript
   - Add hashed version to file name
   - Output bundle to the dist directory
-  
+
 ### `logger:createFile`
-  
+
 Adds the server-side file required for the errorLogger to be inserted into the filesystem.
 
 ### `images`
@@ -552,7 +552,7 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
   Default: `'js/shared'`
 
   Name of the directory where your js error logger file will live.
-  
+
 - #### `file`
 
   Type: `string`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.14.0",
+  "version": "7.15.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",
@@ -21,7 +21,7 @@
     "test": "jest",
     "test:cover": "jest --coverage",
     "test:cover:CI": "cat coverage/lcov.info | coveralls",
-    "lint": "eslint **/*.js",
+    "lint": "eslint **/*.js --fix",
     "release-patch": "release-it patch --non-interactive -p",
     "release-minor": "release-it minor --non-interactive -p",
     "release-major": "release-it major --non-interactive -p"

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -56,7 +56,8 @@ gulp.task('scripts:lint', () => gulp.src([`${pathBuilder.jsSrcDir}/**/*.js`, ...
     // stops watch from breaking on error
     .pipe(plumber(config.gulp.onError))
 
-    .pipe(eslint())
+    .pipe(eslint({ fix: true }))
+    .pipe(gulp.dest(file => file.base))
     .pipe(eslint.format())
     .pipe(eslint.failAfterError())
 );


### PR DESCRIPTION
### Added
- ESLint flag for automatically fixing ESLint rule violations.  Will now fix a number of issues in-line when the lint task is run.
  For more info, check out the [fix rule in the ESLint docs](https://eslint.org/docs/user-guide/command-line-interface#--fix) and to see a list of the rules this will auto-fix, [see the ESLint rule list](https://eslint.org/docs/rules/).

### Updated
- `.gitignore` updated to exclude yalc config files