### PR TITLE
v7.18.0 - Register shared templates as partials rather than helpers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.18.0
+------------------------------
+*April 11, 2018*
+
+### Changed
+- Register shared templates as partials rather than helpers.
+
+
 v7.17.0
 ------------------------------
 *April 10, 2018*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks-dev/assemble.js
+++ b/tasks-dev/assemble.js
@@ -27,7 +27,9 @@ const registerSharedTemplates = () => {
     const templateNames = getTemplateNames(config.docs.excludeTemplateDirs);
 
     templateNames.forEach(templateName => {
-        app.helper(`f-${templateName}`, () => getCompiledTemplate(templateName));
+        const template = getCompiledTemplate(templateName);
+
+        app.partial(`f-${templateName}`, template);
     });
 };
 


### PR DESCRIPTION
### Changed
- Register shared templates as partials rather than helpers.