### PR TITLE
v7.19.0 — Updated docs image related tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.19.0
+------------------------------
+*April 11, 2018*
+
+### Added
+- Added `copy:img:docs` task and documentation.
+
+### Changed
+- The `images:optimise` no longer copies images into the docs asset dist folder.
+- The `images` task will now copies all of the images in the assets dist folder over to the docs dist folder if running a docs task.
+
+
 v7.18.0
 ------------------------------
 *April 11, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ v7.19.0
 
 ### Changed
 - The `images:optimise` no longer copies images into the docs asset dist folder.
-- The `images` task will now copies all of the images in the assets dist folder over to the docs dist folder if running a docs task.
+- The `images` task now copies all of the images in the assets dist folder over to the docs dist folder if running a docs task.
 
 
 v7.18.0

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Runs the following tasks
 
 - #### `images:svg-sprite`
 
-Generate an SVG sprite and copy into the dist directory
+  Generate an SVG sprite and copy into the dist directory
+
+It also runs the [`copy:img`](#copyjs-copycss-copyimg--copyfonts) and [`copy:assets`](#copyassets) tasks.
 
 ### `service-worker`
 
@@ -266,6 +268,10 @@ Pushes the documentation dist directory to the `gh-pages` branch.
 - #### `clean:docs`
 
 Removes document files already in the docs dist directory.
+
+- #### `copy:img:docs`
+
+Copies all of the images in the assets dist folder over to the docs dist folder.
 
 - #### `browser-sync`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.18.0",
+  "version": "7.19.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -74,6 +74,17 @@ gulp.task('copy:img', () => {
 });
 
 /**
+ * `copy:img:docs` Task
+ * ---------------------
+ * Copy all of the images in the assets dist folder over to the docs dist folder.
+ *
+ */
+gulp.task('copy:img:docs', () => gulp.src(`${pathBuilder.imgDistDir}/**/*`)
+    .pipe(plumber(config.gulp.onError))
+    .pipe(gulp.dest(pathBuilder.docsImgDistDir))
+);
+
+/**
  * `copy:fonts` Task
  * ---------------------
  * Copy the specified font assets over to the dist folder.

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -15,7 +15,7 @@ gulp.task('default', callback => {
         ['copy:fonts', 'images'],
         ['css', 'scripts'],
         ['logger:createFile'],
-        ...config.sw.isEnabled ? ['service-worker'] : [],
+        ...(config.sw.isEnabled ? ['service-worker'] : []),
         callback
     );
 

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -22,7 +22,7 @@ gulp.task('images', callback => {
         'clean:images',
         ['copy:img', 'copy:assets'],
         'images:optimise',
-        ...config.docs.outputAssets ? ['copy:img:docs'] : [],
+        ...(config.docs.outputAssets ? ['copy:img:docs'] : []),
         'images:svg-sprite',
         callback
     );

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -22,6 +22,7 @@ gulp.task('images', callback => {
         'clean:images',
         ['copy:img', 'copy:assets'],
         'images:optimise',
+        ...config.docs.outputAssets ? ['copy:img:docs'] : [],
         'images:svg-sprite',
         callback
     );
@@ -50,13 +51,6 @@ gulp.task('images:optimise', () => gulp.src(`${pathBuilder.imgSrcDir}/**`)
             ]
         })
     ], { verbose: config.isDev }))
-
-    .pipe(
-        gulpif(config.docs.outputAssets,
-            // write the files to the docs directory
-            gulp.dest(pathBuilder.docsImgDistDir)
-        )
-    )
 
     // write the files to disk
     .pipe(gulp.dest(`${pathBuilder.imgDistDir}`))


### PR DESCRIPTION
### Added
- Added `copy:img:docs` task and documentation.

### Changed
- The `images:optimise` no longer copies images into the docs asset dist folder.
- The `images` task will now copies all of the images in the assets dist folder over to the docs dist folder if running a docs task.