### PR TITLE
v7.20.0 – Adding `copy:docs` task for copying docs specific files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.20.0
+------------------------------
+*July 6, 2018*
+
+### Added
+- Adding `copy:docs` task for copying docs sites specific files (such as CNAME records)
+
+
 v7.19.0
 ------------------------------
 *April 11, 2018*

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Copies the worker's internal scripts to the dist directory.
 
 Generates a service worker to pre-cache the assets defined in the config.
 
-### `copy:js`, `copy:css`, `copy:img` & `copy:fonts`
+### `copy:js`, `copy:css`, `copy:img`, `copy:fonts` & `copy:docs`
 
 Each of these tasks copies the specified set of assets from the `src` to the `dist` asset folders.
 
@@ -343,7 +343,8 @@ Here is the outline of the configuration options, descriptions of each are below
         js,
         css,
         img,
-        fonts
+        fonts,
+        docs
     },
     docs: {
         rootDir,
@@ -678,13 +679,13 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
 
 ### `copy`
 
-- #### `js`, `css` `img` & `fonts`
+- #### `js`, `css` `img`, `fonts` & `docs`
 
   Type: `Object`
 
   Default: `{}`
 
-  `copy.js`, `copy.css`, `copy.img` and `copy.fonts` each take an object list of assets in the format:
+  `copy.js`, `copy.css`, `copy.img`, `copy.fonts` and `copy.docs` each take an object list of assets in the format:
 
   ```js
     copy:
@@ -703,7 +704,7 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
   - `dest` is a string specifying that destination folder for the asset to be copied to, within the relevant asset `dist` folder.
   - `revision` is a boolean such that if it is `true`, the asset will be [revision hashed](https://www.npmjs.com/package/gulp-rev) when copied to its destination.
 
-  `path` and `dest` must always be defined for each asset you wish to copy.
+  `path` and `dest` must always be defined for each asset you wish to copy (except for `copy:docs` which uses the root `docsDist` path for the `dest`).
 
   The object key (which in the above example is `prism`) of each asset is simply for your own use to identify each asset in your config.
 

--- a/config.js
+++ b/config.js
@@ -95,7 +95,8 @@ const ConfigOptions = () => {
             js: {},
             css: {},
             img: {},
-            fonts: {}
+            fonts: {},
+            docs: {}
         },
 
         /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "7.19.0",
+  "version": "7.20.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks-dev/docs.js
+++ b/tasks-dev/docs.js
@@ -40,7 +40,7 @@ gulp.task('docs:deploy', callback => {
 
     runSequence(
         'clean:docs',
-        ['default', 'assemble'],
+        ['default', 'assemble', 'copy:docs'],
         'docs:release',
         callback
     );

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -95,6 +95,16 @@ gulp.task('copy:fonts', () => {
 });
 
 /**
+ * `copy:docs` Task
+ * ---------------------
+ * Copy any specific files needed for the docs site (i.e. CNAME records)
+ *
+ */
+gulp.task('copy:docs', () => {
+    copy('docs');
+});
+
+/**
  * `copy:assets` Task
  * ---------------------
  * Copy assets from from packages to the dist folder.

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -582,6 +582,25 @@ describe('copy config', () => {
         // Assert
         expect(config.copy.fonts).toEqual(fonts);
     });
+
+    it('copy docs config should be set', () => {
+        expect(config.copy.docs).toEqual({});
+    });
+
+    it('copy docs config can be updated', () => {
+        // Arrange
+        const docs = {
+            docs: {
+                path: '/templates/pages/CNAME'
+            }
+        };
+
+        // Act
+        config.update({ copy: { docs } });
+
+        // Assert
+        expect(config.copy.docs).toEqual(docs);
+    });
 });
 
 describe('documentation config', () => {


### PR DESCRIPTION
### Fixed
- `gulp-gh-pages` was using an old version of `gift` which was stopping the `docs:deploy` task from running.  Have now fixed this issue.