### PR TITLE
v8.1.1 – Updating README with Babel 7 config updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v8.1.1
+------------------------------
+*October 10, 2018*
+
+### Fixed
+- README updated with Babel 7 config changes.  Also includes note about adding Espree v3.5.4 as a resolution when adding linting with ESLint v6.
+
+
 v8.1.0
 ------------------------------
 *October 10, 2018*
 
 ### Changed
 - Updated `f-templates-loader` dependency.
+
 
 v8.0.0
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ That's it! You can now run any of [the Gulp tasks](#the-gulp-tasks).
 
 #### Transpile es2015 code
 
-To ensure that the [`scripts:bundle`](#scriptsbundle) task can transpile es2015 code, add the `babel-preset-es2015` preset to the project:
+To ensure that the [`scripts:bundle`](#scriptsbundle) task can transpile es2015 code, add the `@babel/preset-env` preset to the project:
 
 ```bash
-yarn add babel-preset-es2015
+yarn add @babel/preset-env
 ```
 
-Then add a `.babelrc` file, with the `babel-preset-es2015` preset, to the root of your project:
+Then add a `.babelrc` file, with the `@babel/preset-env` preset, to the root of your project:
 
 ```json
 {
-    "presets": ["es2015"]
+    "presets": ["@babel/preset-env"]
 }
 ```
 
@@ -79,6 +79,18 @@ Add an `.eslintrc` file to the root of your project with the following content t
 If you wish to extend or override these rules you can simply add them after the `extends` line in the `.eslintrc` file.
 
 [For more information on how you can configure eslint check out the documentation](http://eslint.org/docs/user-guide/configuring).
+
+**N.b.** You may also find that you get an error when adding eslint which reads `Parsing error: Cannot read property 'ecmaFeatures' of undefined`.  If you see this message, then add this to your `package.json` followed by running `yarn install`:
+
+```
+"resolutions": {
+  "espree": "3.5.4"
+}
+```
+
+This is a temporary fix dependent on the progress of [this issue open on ESLint](https://github.com/eslint/eslint/issues/10623).
+
+
 
 #### CSS Linting
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",


### PR DESCRIPTION
### Fixed
- README updated with Babel 7 config changes.  Also includes note about adding Espree v3.5.4 as a resolution when adding linting with ESLint v6.