### PR TITLE
8.4.0 – Adjusting copy:assets to work in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v8.4.0
+------------------------------
+*February 12, 2019*
+
+### Fixed
+- Adjusted `copy:assets` task so that it copies the assets over to the relevant docs folder when running in docs mode.
+
+
 v8.3.0
 ------------------------------
 *November 27, 2018*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -109,10 +109,24 @@ gulp.task('copy:docs', () => {
  * Copy assets from from packages to the dist folder.
  *
  */
-gulp.task('copy:assets', () => copyAssets({
-    pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
-    dest: config.assetDistDir,
-    verbose: config.importedAssets.verbose,
-    logger: gutil.log
-})
-    .catch(config.gulp.onError));
+gulp.task('copy:assets', cb => {
+    copyAssets({
+        pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
+        dest: config.assetDistDir,
+        verbose: config.importedAssets.verbose,
+        logger: gutil.log
+    })
+    .catch(config.gulp.onError)
+    .then(() => {
+        if (config.docs.outputAssets) {
+            copyAssets({
+                pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
+                dest: pathBuilder.docsAssetsDistDir,
+                verbose: config.importedAssets.verbose,
+                logger: gutil.log
+            })
+            .catch(config.gulp.onError);
+        }
+    });
+    cb();
+});


### PR DESCRIPTION
### Fixed
- Adjusted `copy:assets` task so that it copies the assets over to the relevant docs folder when running in docs mode.