### PR TITLE
v9.0.1 – Fix for copy task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v9.0.1
+------------------------------
+*December 11, 2019*
+
+## Fixed
+- Copy issue where for some reason the `gulpif` package was incorrectly stopping all images being copied over when `gulp.dest` was run. Have split out the base copy and the docs copy streams so they don't impact one another.
+
+
 v9.0.0
 ------------------------------
 *November 12, 2019*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "author": "Damian Mullins <damian.mullins@just-eat.com> (http://www.damianmullins.com)",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -30,13 +30,21 @@ const copy = fileType => {
                     rev()
                 ))
 
-                .pipe(gulp.dest(assetDist))
+                .pipe(gulp.dest(assetDist));
 
-                // output to docs assets folder
-                .pipe(gulpif(
-                    config.docs.outputAssets,
-                    gulp.dest(assetDocsDist)
-                ));
+            // this docs copy is separate as the gulpif() was terminating the previous stream before all files had copied
+            if (config.docs.outputAssets) {
+                gulp.src(assetSrc)
+                    .pipe(plumber(config.gulp.onError))
+
+                    .pipe(gulpif(
+                        asset.revision,
+                        rev()
+                    ))
+
+                    // output to docs assets folder
+                    .pipe(gulp.dest(assetDocsDist));
+            }
         } else {
             gutil.log(gutil.colors.red.bold('Error copying file - path not defined'));
         }
@@ -116,17 +124,17 @@ gulp.task('copy:assets', cb => {
         verbose: config.importedAssets.verbose,
         logger: gutil.log
     })
-    .catch(config.gulp.onError)
-    .then(() => {
-        if (config.docs.outputAssets) {
-            copyAssets({
-                pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
-                dest: pathBuilder.docsAssetsDistDir,
-                verbose: config.importedAssets.verbose,
-                logger: gutil.log
-            })
-            .catch(config.gulp.onError);
-        }
-    });
+        .catch(config.gulp.onError)
+        .then(() => {
+            if (config.docs.outputAssets) {
+                copyAssets({
+                    pkgSrcGlob: config.importedAssets.importedAssetsSrcGlob,
+                    dest: pathBuilder.docsAssetsDistDir,
+                    verbose: config.importedAssets.verbose,
+                    logger: gutil.log
+                })
+                    .catch(config.gulp.onError);
+            }
+        });
     cb();
 });


### PR DESCRIPTION
## Fixed
- Copy issue where for some reason the `gulpif` package was incorrectly stopping all images being copied over when `gulp.dest` was run. Have split out the base copy and the docs copy streams so they don't impact one another.