### PR TITLE
v10.5.0 - Add `customTasks` to JS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v10.5.0
+------------------------------
+*May 25, 2022*
+
+### Added
+- `customTasks` property to JavaScript config.
+  - This allows tasks (provided by the consuming application) to be run as part of the `gulp:scripts` command, in parallel with `scripts:bundle`.
+
+
 v10.4.0
 ------------------------------
 *May 23, 2022*

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ Runs the following tasks
 
   Removes any JavaScript already in the dist directory.
 
+- #### Custom Tasks
+
+  The names of custom tasks can be passed into the config object to be run here. See [`customTasks`](#customtasks) for more details.
+
+
 - #### `scripts:bundle`
 
   Performs a variety of tasks including;
@@ -319,6 +324,7 @@ Here is the outline of the configuration options, descriptions of each are below
             },
             …
         ],
+        customTasks,
         jsDir,
         lintPaths,
         allowEmpty
@@ -507,6 +513,18 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
     Default: `'script.js'`
 
     The filename for the JavaScript bundle once compiled.
+
+- #### `customTasks`
+
+  Type: `array<string>`
+
+  Default: `[]`
+
+  Array of strings, containing the names of the custom tasks to be run as part of the `gulp:scripts` command, in parallel with `scripts:bundle`.
+
+  These should be defined by (or made available within) the consuming application, e.g., compiling third-party libraries within a `scripts:libs` task.
+
+  Gulp 4 does not easily allow for the entire default `gulp:scripts` implementation to be overridden, so any extra JS-related tasks that you need to run should be passed in here.
 
 - #### `jsDir`
 

--- a/config.js
+++ b/config.js
@@ -45,6 +45,7 @@ const ConfigOptions = () => {
                     distFile: 'script.js'
                 }
             },
+            customTasks: [],
             jsDir: 'js',
             lintPaths: [],
             allowEmpty: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "contributors": [

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -117,7 +117,7 @@ gulp.task('scripts:bundle', async () => {
             .pipe(gulpif(
                 config.misc.showFileSize,
                 size({
-                    title: 'Bundled JS Report – unminified build –',
+                    title: 'Bundled JS Report - unminified build -',
                     showFiles: config.misc.showFiles
                 })
             ))
@@ -172,7 +172,7 @@ gulp.task('scripts:bundle', async () => {
             .pipe(gulpif(
                 config.misc.showFileSize,
                 size({
-                    title: 'Bundled JS Report – minified build –',
+                    title: 'Bundled JS Report - minified build -',
                     showFiles: config.misc.showFiles
                 })
             ))
@@ -182,7 +182,6 @@ gulp.task('scripts:bundle', async () => {
 
     return merge(...bundleTasks);
 });
-
 
 /**
  *  `scripts` Task
@@ -194,6 +193,9 @@ gulp.task('scripts', gulp.series(
     'scripts:lint',
     'scripts:test',
     'clean:scripts',
-    'scripts:bundle',
+    gulp.parallel(
+        ...config.js.customScripts,
+        'scripts:bundle'
+    ),
     'copy:js'
 ));


### PR DESCRIPTION
### Added
- `customTasks` property to JavaScript config.
  - This allows tasks (provided by the consuming application) to be run as part of the `gulp:scripts` command, in parallel with `scripts:bundle`.