### PR TITLE
v11.2.0 – Added optimiseSVGs config control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v11.2.0
+------------------------------
+*December 22, 2022*
+
+### Changed
+- `config.img.optimiseSVGs` which allows more granular control over whether SVGs get minified or not.
+
+
 v11.1.0
 ------------------------------
 *December 22, 2022*

--- a/README.md
+++ b/README.md
@@ -337,7 +337,10 @@ Here is the outline of the configuration options, descriptions of each are below
     },
     img: {
         imgDir,
-        svgSpriteFilename
+        optimiseImages,
+        optimiseSVGs,
+        spriteSvgs,
+        svgSpriteFilename,
     },
     importedAssets: {
         importedAssetsSrcGlob,
@@ -613,6 +616,30 @@ Will add a content hash to the JS and CSS filenames, generating a new filename i
   Name of the directory where your image files are kept.
 
   Processed image files will be placed inside a directory with the same name.
+
+- #### `optimiseImages`
+
+  Type: `boolean`
+
+  Default: `'true'`
+
+  Controls whether or not all image typesare optimised as part of the image tasks.
+
+- #### `optimiseSVGs`
+
+  Type: `boolean`
+
+  Default: `'true'`
+
+  Controls whether or not SVGs are optimised as part of the image tasks.
+
+- #### `spriteSvgs`
+
+  Type: `boolean`
+
+  Default: `'true'`
+
+  Controls whether or not SVGs are turned into an SVG Sprite as part of the image tasks
 
 - #### `svgSpriteFilename`
 

--- a/config.js
+++ b/config.js
@@ -68,6 +68,7 @@ const ConfigOptions = () => {
             imgDir: 'img',
             svgSpriteFilename: 'sprite.svg',
             optimiseImages: true,
+            optimiseSVGs: true,
             spriteSvgs: true
         },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/gulp-build-fozzie",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "Gulp build tasks for use across Fozzie modules",
   "main": "index.js",
   "contributors": [

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -27,11 +27,13 @@ gulp.task('images:optimise', () => gulp.src(`${pathBuilder.imgSrcDir}/**`)
         imagemin.gifsicle({ optimizationLevel: 3 }),
         imagemin.mozjpeg(),
         imagemin.optipng({ optimizationLevel: 5 }),
-        imagemin.svgo({
-            plugins: [
-                { removeViewBox: false }
-            ]
-        })
+        ...(config.img.optimiseSVGs ?
+            [imagemin.svgo({
+                plugins: [
+                    { removeViewBox: false }
+                ]
+            })] : []
+        )
     ], { verbose: config.isDev }))
 
     // write the files to disk


### PR DESCRIPTION
### Changed
- `config.img.optimiseSVGs` which allows more granular control over whether SVGs get minified or not.